### PR TITLE
Fix convert module: API key passthrough, image extraction, auto mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 [project.optional-dependencies]
 convert = [
     "markitdown>=0.1.0",
-    "markit-mistral",
+    "markit-mistral>=0.2.0",
 ]
 dev = [
     "pytest>=8.0.0",

--- a/src/opencite/cli.py
+++ b/src/opencite/cli.py
@@ -133,8 +133,16 @@ def create_parser() -> argparse.ArgumentParser:
     )
     convert_p.add_argument(
         "--converter",
-        choices=["markitdown", "mistral"],
-        default="markitdown",
+        choices=["markitdown", "mistral", "auto"],
+        default="auto",
+    )
+    convert_p.add_argument(
+        "--extract-images",
+        action="store_true",
+        help="extract images from PDF (mistral only)",
+    )
+    convert_p.add_argument(
+        "--images-dir", metavar="DIR", help="directory for extracted images"
     )
 
     # -- ids --
@@ -396,18 +404,33 @@ async def _cmd_pdf(args: argparse.Namespace, config: object) -> int:
         from opencite.convert import convert_pdf
 
         md_out = path.with_suffix(".md")
-        convert_pdf(str(path), output_path=str(md_out), converter=args.converter)
+        convert_pdf(
+            str(path),
+            output_path=str(md_out),
+            converter=args.converter,
+            mistral_api_key=config.mistral_api_key,
+        )
         print(f"Converted: {md_out}", file=sys.stderr)
 
     return 0
 
 
-async def _cmd_convert(args: argparse.Namespace, config: object) -> int:  # noqa: ARG001
+async def _cmd_convert(args: argparse.Namespace, config: object) -> int:
     """Handle the 'convert' subcommand."""
+    from opencite.config import Config
     from opencite.convert import convert_pdf
 
+    assert isinstance(config, Config)
+
     output_path = args.output
-    md_text = convert_pdf(args.file, output_path=output_path, converter=args.converter)
+    md_text = convert_pdf(
+        args.file,
+        output_path=output_path,
+        converter=args.converter,
+        extract_images=args.extract_images,
+        images_dir=getattr(args, "images_dir", None),
+        mistral_api_key=config.mistral_api_key,
+    )
 
     if not output_path:
         print(md_text)

--- a/src/opencite/convert.py
+++ b/src/opencite/convert.py
@@ -12,6 +12,9 @@ def convert_pdf(
     pdf_path: str | Path,
     output_path: str | Path | None = None,
     converter: str = "auto",
+    extract_images: bool = False,
+    images_dir: str | Path | None = None,
+    mistral_api_key: str = "",
 ) -> str:
     """Convert a PDF file to markdown.
 
@@ -20,6 +23,9 @@ def convert_pdf(
         output_path: Optional path for the output markdown file.
         converter: Which converter to use: "markitdown", "mistral", or "auto".
             Auto uses mistral if MISTRAL_API_KEY is set, otherwise markitdown.
+        extract_images: Whether to extract images (mistral only).
+        images_dir: Directory for extracted images (defaults to output_path parent).
+        mistral_api_key: Mistral API key (falls back to env var).
 
     Returns:
         The markdown text.
@@ -29,14 +35,21 @@ def convert_pdf(
         raise FileNotFoundError(f"PDF not found: {pdf_path}")
 
     if converter == "auto":
-        converter = _pick_converter()
+        converter = _pick_converter(mistral_api_key)
 
     if converter == "mistral":
-        md_text = _convert_with_mistral(pdf_path)
+        md_text = _convert_with_mistral(
+            pdf_path,
+            output_path=output_path,
+            extract_images=extract_images,
+            images_dir=images_dir,
+            api_key=mistral_api_key,
+        )
     else:
         md_text = _convert_with_markitdown(pdf_path)
 
-    if output_path:
+    if output_path and not extract_images:
+        # When extract_images is True, markit-mistral handles output writing
         out = Path(output_path)
         out.write_text(md_text, encoding="utf-8")
         logger.info("Markdown written to %s", out)
@@ -44,11 +57,11 @@ def convert_pdf(
     return md_text
 
 
-def _pick_converter() -> str:
+def _pick_converter(api_key: str = "") -> str:
     """Auto-select converter based on available API keys."""
     import os
 
-    if os.environ.get("MISTRAL_API_KEY"):
+    if api_key or os.environ.get("MISTRAL_API_KEY"):
         return "mistral"
     return "markitdown"
 
@@ -68,15 +81,38 @@ def _convert_with_markitdown(pdf_path: Path) -> str:
     return result.text_content
 
 
-def _convert_with_mistral(pdf_path: Path) -> str:
+def _convert_with_mistral(
+    pdf_path: Path,
+    output_path: str | Path | None = None,
+    extract_images: bool = False,
+    images_dir: str | Path | None = None,
+    api_key: str = "",
+) -> str:
     """Convert using markit-mistral (API-based, better for complex layouts)."""
     try:
         from markit_mistral import MarkitMistral
     except ImportError as e:
         raise ImportError(
-            "markit-mistral is required for Mistral PDF conversion. "
+            "markit-mistral>=0.2.0 is required for Mistral PDF conversion. "
             "Install with: uv pip install opencite[convert]"
         ) from e
 
-    converter = MarkitMistral()
+    kwargs: dict[str, str] = {}
+    if api_key:
+        kwargs["api_key"] = api_key
+
+    converter = MarkitMistral(**kwargs)
+
+    if extract_images and output_path:
+        # Use convert_file for full output with images
+        out = Path(output_path)
+        output_dir = Path(images_dir) if images_dir else out.parent
+        converter.convert_file(
+            pdf_path,
+            output_path=out,
+            output_dir=output_dir,
+            extract_images=True,
+        )
+        return out.read_text(encoding="utf-8") if out.exists() else ""
+
     return converter.convert(str(pdf_path))

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,0 +1,101 @@
+"""Tests for opencite.convert."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from opencite.convert import _pick_converter, convert_pdf
+
+
+class TestPickConverter:
+    def test_defaults_to_markitdown(self, monkeypatch):
+        monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
+        assert _pick_converter() == "markitdown"
+
+    def test_mistral_when_env_set(self, monkeypatch):
+        monkeypatch.setenv("MISTRAL_API_KEY", "test-key")
+        assert _pick_converter() == "mistral"
+
+    def test_mistral_when_api_key_passed(self, monkeypatch):
+        monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
+        assert _pick_converter(api_key="explicit-key") == "mistral"
+
+    def test_api_key_param_takes_priority(self, monkeypatch):
+        monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
+        assert _pick_converter(api_key="key") == "mistral"
+
+
+class TestConvertPdf:
+    def test_file_not_found(self):
+        with pytest.raises(FileNotFoundError, match="PDF not found"):
+            convert_pdf("/nonexistent/paper.pdf")
+
+    def test_markitdown_import_error(self, monkeypatch):
+        """When markitdown is not installed, helpful error is raised."""
+        import opencite.convert as conv
+
+        def mock_convert(_pdf_path):
+            raise ImportError("markitdown is required")
+
+        monkeypatch.setattr(conv, "_convert_with_markitdown", mock_convert)
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            f.write(b"%PDF-1.4 fake")
+            f.flush()
+            with pytest.raises(ImportError, match="markitdown"):
+                convert_pdf(f.name, converter="markitdown")
+
+    def test_mistral_import_error(self, monkeypatch):
+        """When markit-mistral is not installed, helpful error is raised."""
+        import opencite.convert as conv
+
+        def mock_convert(_pdf_path, **_kwargs):
+            raise ImportError("markit-mistral>=0.2.0 is required")
+
+        monkeypatch.setattr(conv, "_convert_with_mistral", mock_convert)
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            f.write(b"%PDF-1.4 fake")
+            f.flush()
+            with pytest.raises(ImportError, match="markit-mistral"):
+                convert_pdf(f.name, converter="mistral")
+
+    def test_auto_selects_markitdown_without_key(self, monkeypatch):
+        """Auto mode selects markitdown when no Mistral key available."""
+        monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
+        import opencite.convert as conv
+
+        called_with = {}
+
+        def mock_markitdown(_pdf_path):
+            called_with["converter"] = "markitdown"
+            return "# Mock output"
+
+        monkeypatch.setattr(conv, "_convert_with_markitdown", mock_markitdown)
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            f.write(b"%PDF-1.4 fake")
+            f.flush()
+            result = convert_pdf(f.name, converter="auto")
+
+        assert called_with["converter"] == "markitdown"
+        assert result == "# Mock output"
+
+    def test_output_written_to_file(self, monkeypatch):
+        """Output is written to file when output_path specified."""
+        import opencite.convert as conv
+
+        monkeypatch.setattr(conv, "_convert_with_markitdown", lambda _p: "# Content")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            pdf = Path(tmp) / "test.pdf"
+            pdf.write_bytes(b"%PDF-1.4 fake")
+            out = Path(tmp) / "test.md"
+
+            convert_pdf(str(pdf), output_path=str(out), converter="markitdown")
+
+            assert out.exists()
+            assert out.read_text() == "# Content"


### PR DESCRIPTION
## Summary
- Pass `mistral_api_key` from unified config to convert functions (no longer env-var-only)
- Add `--extract-images` and `--images-dir` CLI flags for the convert subcommand
- Add `"auto"` to converter choices, change default from `"markitdown"` to `"auto"`
- Pin `markit-mistral>=0.2.0` in pyproject.toml dependencies
- 9 new convert tests

## Test plan
- [x] 175 tests pass, 0 failures
- [x] ruff check clean
- [x] Auto-detection picks mistral when API key passed via config
- [x] File not found raises clear error
- [x] Import errors suggest install command

Depends on PR #9 (config overhaul)
Closes #6