### PR TITLE
Add pre-commit hooks: ruff, ty, typos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.2
+    hooks:
+      - id: ruff
+        args: [--fix, --unsafe-fixes]
+      - id: ruff-format
+
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.43.5
+    hooks:
+      - id: typos
+
+  - repo: local
+    hooks:
+      - id: ty
+        name: ty (type check)
+        entry: uv run ty check
+        language: system
+        types: [python]
+        pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
     "pytest-cov>=5.0.0",
     "pytest-asyncio>=0.24.0",
     "ruff>=0.8.0",
+    "ty>=0.0.18",
     "pre-commit>=4.0.0",
 ]
 
@@ -68,6 +69,14 @@ ignore = ["E501"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["opencite"]
+
+[tool.ty.src]
+exclude = ["tests/"]
+
+[tool.ty.rules]
+# Downgrade to warnings until type annotations are tightened across the codebase
+invalid-argument-type = "warn"
+unresolved-attribute = "warn"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

- Add `.pre-commit-config.yaml` with ruff (lint + format), ty (type check), and typos (spell check)
- ruff hooks use `--fix --unsafe-fixes` per project conventions, staged files only
- ty runs as a local hook (no official pre-commit repo yet, tracked at astral-sh/ty#269)
- Add `ty>=0.0.18` to dev dependencies
- Configure `[tool.ty]` in pyproject.toml: exclude tests/ and downgrade `invalid-argument-type`/`unresolved-attribute` to warnings until type annotations are tightened

## Test plan

- [x] `pre-commit run --all-files` passes all 4 hooks
- [x] All 203 tests pass
- [x] Pre-commit hooks run on commit (verified via the commit itself)