### PR TITLE
Add PMC full-text retrieval via BioC API

### DIFF
--- a/.context/plan.md
+++ b/.context/plan.md
@@ -1,0 +1,159 @@
+# Plan: PMC Full-Text Retrieval (Issue #19)
+
+## Goal
+
+Add PMC BioC API integration to retrieve structured full-text articles from
+the PMC Open Access subset and convert them directly to markdown, bypassing
+the PDF download + conversion pipeline entirely.
+
+## API Choice: BioC REST API
+
+After evaluating PMC OA Web Service, OAI-PMH, efetch, and BioC APIs, the
+**BioC API** is the best fit:
+
+- **URL**: `https://www.ncbi.nlm.nih.gov/research/bionlp/RESTful/pmcoa.cgi/BioC_json/{PMCID}/unicode`
+- Returns structured JSON with typed passages (TITLE, ABSTRACT, INTRO, METHODS, RESULTS, DISCUSS, CONCL, FIG, TABLE, REF)
+- Each passage has `section_type`, `type` (paragraph, title_1, title_2, fig_caption, table, etc.), and `text`
+- Figure filenames embedded in passage `infons.file` (e.g., `WJR-9-27-g001.jpg`)
+- No API key required; OA subset only; clear error for non-OA articles
+- Supports batch queries with comma-separated IDs
+
+**PMC OA Web Service** (`oa.fcgi`) will be used as a secondary check to
+confirm OA status and retrieve image tgz when needed.
+
+## Implementation Steps
+
+### Step 1: Create `src/opencite/clients/pmc.py` -- PMC BioC Client
+
+New client extending `BaseClient` with:
+
+- `PMCClient(BaseClient)` with base URL `https://www.ncbi.nlm.nih.gov/research/bionlp/RESTful`
+- Rate limit: 3 req/sec (per PMC guidelines)
+- `async fetch_full_text(pmcid: str) -> dict | None` -- fetch BioC JSON for one article
+- `async check_oa_status(pmcid: str) -> bool` -- query OA Web Service to check if article is in OA subset
+- `async fetch_image(pmcid: str, filename: str, dest: Path) -> Path | None` -- download a figure image from PMC
+
+Image URL strategy: Use the OA tgz link from the OA API, or try
+`https://pmc.ncbi.nlm.nih.gov/articles/instance/{pmcid}/bin/{filename}`
+
+### Step 2: Create `src/opencite/pmc_convert.py` -- BioC JSON to Markdown
+
+New module for converting BioC JSON to clean markdown:
+
+- `bioc_to_markdown(bioc_data: dict, images_dir: Path | None = None) -> str`
+  - Iterates over `documents[0].passages`
+  - Maps section types to markdown structure:
+    - TITLE -> `# Title`
+    - ABSTRACT -> `## Abstract\n\ntext`
+    - INTRO -> `## Introduction\n\ntext` (with `title_1`/`title_2` as sub-headers)
+    - METHODS -> `## Methods\n\ntext`
+    - RESULTS -> `## Results\n\ntext`
+    - DISCUSS -> `## Discussion\n\ntext`
+    - CONCL -> `## Conclusion\n\ntext`
+    - FIG -> `![caption](images/filename)` with caption text
+    - TABLE -> markdown table formatting (from `table` type passages)
+    - REF -> `## References\n\n` with numbered references
+  - `type` field within passages determines formatting:
+    - `title_1` -> `## Section Title`
+    - `title_2` -> `### Sub-section Title`
+    - `paragraph` -> plain text block
+    - `fig_caption` / `fig_title_caption` -> figure with image ref
+    - `table_caption` / `table` -> table formatting
+    - `ref` -> reference entry
+  - Returns clean markdown string
+
+- `extract_figure_files(bioc_data: dict) -> list[tuple[str, str]]`
+  - Returns list of `(figure_id, filename)` pairs from passage infons
+
+### Step 3: Create `src/opencite/fulltext.py` -- Full-Text Retriever
+
+New module parallel to `pdf.py`, orchestrates PMC full-text retrieval:
+
+- `FullTextRetriever` class (async context manager like PDFRetriever)
+  - `__init__(config: Config)` -- creates PMCClient and IDConverterClient
+  - `async retrieve(identifier: str, output_dir: str = ".", paper: Paper | None = None, extract_images: bool = True) -> Path | None`
+    1. Resolve PMCID (from paper, or via ID converter if only DOI/PMID given)
+    2. Check OA status via PMC OA API
+    3. Fetch BioC JSON via PMC BioC API
+    4. Convert to markdown via `bioc_to_markdown()`
+    5. Optionally download figure images
+    6. Write markdown file to output_dir
+    7. Return path to markdown file, or None if not available
+
+### Step 4: Integrate into PDF pipeline (`pdf.py`)
+
+Modify `PDFRetriever.download()` to try full-text first when `--convert` is
+the end goal:
+
+- Add a new method `async retrieve_as_markdown(identifier, output_dir, paper) -> Path | None`
+  that uses `FullTextRetriever` internally
+- When the caller wants markdown (indicated by a new parameter), try PMC full
+  text first, fall back to PDF download + conversion
+- Keep existing PDF-only flow unchanged for users who just want the PDF
+
+### Step 5: Update `batch.py`
+
+Modify `batch_download()` to accept `prefer_fulltext: bool = True`:
+
+- When `convert=True` and `prefer_fulltext=True`:
+  1. Try PMC full-text retrieval first (no PDF needed)
+  2. If successful, write markdown directly to `markdown/` dir
+  3. If not available, fall back to PDF download + conversion
+- Track fulltext_retrieved count in `BatchResult`
+- Add `fulltext_retrieved: int = 0` field to `BatchResult`
+
+### Step 6: Update CLI (`cli.py`)
+
+- `pdf` subcommand with `--convert`: automatically try PMC full-text first,
+  fall back to PDF. Add `--no-fulltext` flag to skip PMC and force PDF path.
+- `batch-fetch` subcommand with `--convert`: same behavior. Add `--no-fulltext`.
+- No new subcommand needed; the feature is transparent to the user.
+
+### Step 7: Tests
+
+Create `tests/test_pmc_client.py`:
+- Test BioC JSON parsing (with sample fixture data)
+- Test OA status check (OA vs non-OA responses)
+- Test error handling (network errors, malformed responses)
+
+Create `tests/test_pmc_convert.py`:
+- Test `bioc_to_markdown()` with sample BioC JSON covering all section types
+- Test figure extraction
+- Test table handling
+- Test edge cases (empty passages, missing fields)
+
+Create `tests/test_fulltext.py`:
+- Test PMCID resolution flow
+- Test fallback when article is not OA
+- Test integration with markdown output
+
+Add integration tests (marked `@pytest.mark.integration`):
+- Real PMC BioC API call with known OA article
+- Real OA status check
+
+## File Changes Summary
+
+| File | Action | Description |
+|------|--------|-------------|
+| `src/opencite/clients/pmc.py` | CREATE | PMC BioC client |
+| `src/opencite/pmc_convert.py` | CREATE | BioC JSON to markdown converter |
+| `src/opencite/fulltext.py` | CREATE | Full-text retrieval orchestrator |
+| `src/opencite/pdf.py` | MODIFY | Add markdown retrieval option |
+| `src/opencite/batch.py` | MODIFY | Add fulltext preference to batch |
+| `src/opencite/cli.py` | MODIFY | Add --no-fulltext flag |
+| `tests/test_pmc_client.py` | CREATE | PMC client tests |
+| `tests/test_pmc_convert.py` | CREATE | BioC to markdown tests |
+| `tests/test_fulltext.py` | CREATE | Full-text retriever tests |
+
+## Implementation Order
+
+1. `clients/pmc.py` + `tests/test_pmc_client.py` (foundation)
+2. `pmc_convert.py` + `tests/test_pmc_convert.py` (conversion logic)
+3. `fulltext.py` + `tests/test_fulltext.py` (orchestration)
+4. Integrate into `pdf.py`, `batch.py`, `cli.py`
+5. Integration tests
+6. Update CLAUDE.md architecture docs
+
+## Open Questions
+
+None; all APIs tested and verified working.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,21 +40,24 @@ uv run ruff format src/ tests/   # format
 - `exceptions.py` -- `OpenCiteError` hierarchy: `APIError`, `RateLimitError`, `APIKeyError`, etc.
 - `cli.py` -- argparse with subcommands: search, lookup, cite, canonical, pdf, convert, ids, batch-fetch, config
 - `utils.py` -- title normalization, fuzzy matching, author name parsing, abstract reconstruction
-- `clients/` -- per-API async clients with rate limiting (base.py, openalex.py, semantic_scholar.py, pubmed.py, arxiv.py, biorxiv.py, id_converter.py)
+- `clients/` -- per-API async clients with rate limiting (base.py, openalex.py, semantic_scholar.py, pubmed.py, arxiv.py, biorxiv.py, pmc.py, id_converter.py)
 - `search.py` -- `SearchOrchestrator` for parallel multi-source search with dedup/merge
 - `citations.py` -- `CitationExplorer` for citation graph traversal and canonical paper discovery
 - `dedup.py` -- DOI + fuzzy title deduplication with paper merging
 - `bibtex.py` -- BibTeX fetch (S2 citationStyles, DOI negotiation) and generation
-- `pdf.py` -- multi-source PDF retrieval pipeline with publisher-authenticated downloads
+- `pdf.py` -- multi-source PDF retrieval pipeline with publisher-authenticated downloads; `retrieve_as_markdown()` tries PMC full text before PDF fallback
+- `fulltext.py` -- `FullTextRetriever` for PMC BioC full-text retrieval, bypasses PDF pipeline for OA articles
+- `pmc_convert.py` -- BioC JSON to markdown converter with section structure, figures, tables, and references
 - `convert.py` -- PDF-to-markdown (markitdown, markit-mistral; both included by default) with image extraction support
-- `batch.py` -- batch PDF download and conversion with controlled concurrency; organizes into pdf/, markdown/, markdown/img/ subdirs when converting
+- `batch.py` -- batch PDF download and conversion with controlled concurrency; prefers PMC full text when converting; organizes into pdf/, markdown/, markdown/img/ subdirs
 - `formatters/` -- output formatters (text, json, bibtex, csv)
 
 ### Key Design Patterns
 - **IDSet** is frozen (immutable) and centralizes all identifier types (DOI, PMID, PMCID, OpenAlex, S2, ArXiv) for cross-API lookup
 - **Paper.data_sources** tracks which APIs contributed data (provenance)
 - **BaseClient** ABC provides rate limiting (token bucket), retry with backoff, httpx session management
-- Rate limits: OpenAlex 100 req/sec, PubMed 10 req/sec, Semantic Scholar 1 req/sec, arXiv 3 req/sec, bioRxiv 10 req/sec
+- Rate limits: OpenAlex 100 req/sec, PubMed 10 req/sec, Semantic Scholar 1 req/sec, arXiv 3 req/sec, bioRxiv 10 req/sec, PMC 3 req/sec
+- **Full-text retrieval** (when `--convert` is used): PMC BioC API for OA articles -> structured markdown (no PDF needed). Uses `--no-fulltext` to skip.
 - PDF retrieval tries sources in priority: publisher APIs (if tokens configured) -> OpenAlex/S2 PDF locations -> PMC OA -> direct arXiv/bioRxiv URL -> DOI content negotiation
 - PDF-to-markdown `auto` mode: if `MISTRAL_API_KEY` is set, use markit-mistral (better for math/complex layouts); otherwise fall back to markitdown (free)
 - Config loading priority: TOML < `.env` files < environment variables
@@ -63,7 +66,7 @@ uv run ruff format src/ tests/   # format
 ### API Integrations
 - **OpenAlex** -- `pyalex` library; broadest coverage (250M+ works); best for PDF URLs, filtering, citation counts
 - **Semantic Scholar** -- `httpx` REST; TLDR summaries, SPECTER embeddings, batch 500 IDs, `citationStyles` for BibTeX
-- **PubMed/PMC** -- NCBI eutils XML; MeSH terms, PMC full text, ID Converter API
+- **PubMed/PMC** -- NCBI eutils XML; MeSH terms, ID Converter API; PMC BioC REST API for structured full-text (OA subset, ~4M+ articles)
 - **arXiv** -- Atom v1 API; search + direct lookup by arXiv ID; no key required; direct PDF at `arxiv.org/pdf/{id}`
 - **bioRxiv/medRxiv** -- CrossRef (`prefix:10.1101`) for keyword search; bioRxiv Content API for DOI lookup with biorxiv/medrxiv server fallback; no key required
 

--- a/src/opencite/batch.py
+++ b/src/opencite/batch.py
@@ -25,6 +25,7 @@ class BatchResult:
     total: int = 0
     downloaded: int = 0
     converted: int = 0
+    fulltext_retrieved: int = 0
     failed: list[tuple[str, str]] = field(default_factory=list)
     conversion_failed: list[tuple[str, str]] = field(default_factory=list)
 
@@ -33,6 +34,7 @@ class BatchResult:
             "total": self.total,
             "downloaded": self.downloaded,
             "converted": self.converted,
+            "fulltext_retrieved": self.fulltext_retrieved,
             "failed": [{"id": id_, "reason": reason} for id_, reason in self.failed],
             "conversion_failed": [
                 {"id": id_, "reason": reason} for id_, reason in self.conversion_failed
@@ -131,8 +133,13 @@ async def batch_download(
     convert: bool = False,
     converter: str = "auto",
     concurrency: int = 3,
+    prefer_fulltext: bool = True,
 ) -> BatchResult:
     """Download PDFs for multiple papers with controlled concurrency.
+
+    When convert=True and prefer_fulltext=True, tries PMC full-text
+    retrieval first (bypassing PDF entirely). Falls back to PDF download
+    + conversion if full text is not available.
 
     Args:
         ids: List of DOIs or other identifiers.
@@ -141,6 +148,7 @@ async def batch_download(
         convert: Whether to also convert to markdown.
         converter: Converter to use for markdown conversion.
         concurrency: Max concurrent downloads.
+        prefer_fulltext: Try PMC full-text before PDF when converting.
 
     Returns:
         BatchResult with summary statistics.
@@ -169,6 +177,24 @@ async def batch_download(
     async def _process_one(identifier: str, retriever: PDFRetriever) -> None:
         async with semaphore:
             try:
+                # When converting, try PMC full-text first
+                if convert and prefer_fulltext and md_dir is not None:
+                    md_path = await retriever.retrieve_as_markdown(
+                        identifier=identifier,
+                        output_dir=str(md_dir),
+                        extract_images=True,
+                        converter=converter,
+                    )
+                    if md_path:
+                        result.fulltext_retrieved += 1
+                        result.converted += 1
+                        print(
+                            f"  OK (fulltext): {identifier} -> {md_path.name}",
+                            file=sys.stderr,
+                        )
+                        return
+
+                # PDF-only download (or fulltext failed/disabled)
                 path = await retriever.download(
                     identifier=identifier,
                     output_dir=str(pdf_dir),

--- a/src/opencite/batch.py
+++ b/src/opencite/batch.py
@@ -14,6 +14,7 @@ from opencite.pdf import PDFRetriever
 
 if TYPE_CHECKING:
     from opencite.config import Config
+    from opencite.fulltext import FullTextRetriever
 
 logger = logging.getLogger(__name__)
 
@@ -174,17 +175,24 @@ async def batch_download(
                 "Using markitdown; images will not be extracted."
             )
 
-    async def _process_one(identifier: str, retriever: PDFRetriever) -> None:
+    async def _try_fulltext(
+        identifier: str, ft_retriever: FullTextRetriever
+    ) -> Path | None:
+        """Try PMC full-text retrieval (returns markdown path or None)."""
+        return await ft_retriever.retrieve(
+            identifier=identifier,
+            output_dir=str(md_dir),
+            extract_images=True,
+        )
+
+    async def _process_one(
+        identifier: str, retriever: PDFRetriever, ft_retriever: FullTextRetriever | None
+    ) -> None:
         async with semaphore:
             try:
                 # When converting, try PMC full-text first
-                if convert and prefer_fulltext and md_dir is not None:
-                    md_path = await retriever.retrieve_as_markdown(
-                        identifier=identifier,
-                        output_dir=str(md_dir),
-                        extract_images=True,
-                        converter=converter,
-                    )
+                if convert and prefer_fulltext and md_dir is not None and ft_retriever:
+                    md_path = await _try_fulltext(identifier, ft_retriever)
                     if md_path:
                         result.fulltext_retrieved += 1
                         result.converted += 1
@@ -243,8 +251,22 @@ async def batch_download(
                 result.failed.append((identifier, str(e)))
                 print(f"  FAIL: {identifier} ({e})", file=sys.stderr)
 
-    async with PDFRetriever(config) as retriever:
-        tasks = [asyncio.create_task(_process_one(id_, retriever)) for id_ in ids]
-        await asyncio.gather(*tasks)
+    ft_instance: FullTextRetriever | None = None
+    if convert and prefer_fulltext:
+        from opencite.fulltext import FullTextRetriever as _FTR
+
+        ft_instance = _FTR(config)
+        await ft_instance.__aenter__()
+
+    try:
+        async with PDFRetriever(config) as retriever:
+            tasks = [
+                asyncio.create_task(_process_one(id_, retriever, ft_instance))
+                for id_ in ids
+            ]
+            await asyncio.gather(*tasks)
+    finally:
+        if ft_instance is not None:
+            await ft_instance.__aexit__()
 
     return result

--- a/src/opencite/cli.py
+++ b/src/opencite/cli.py
@@ -130,6 +130,11 @@ def create_parser() -> argparse.ArgumentParser:
         choices=["markitdown", "mistral", "auto"],
         default="auto",
     )
+    pdf_p.add_argument(
+        "--no-fulltext",
+        action="store_true",
+        help="skip PMC full-text retrieval, force PDF download",
+    )
 
     # -- convert --
     convert_p = subparsers.add_parser("convert", help="convert a PDF to markdown")
@@ -189,6 +194,11 @@ def create_parser() -> argparse.ArgumentParser:
     )
     batch_p.add_argument(
         "--summary", metavar="FILE", help="write JSON summary report to file"
+    )
+    batch_p.add_argument(
+        "--no-fulltext",
+        action="store_true",
+        help="skip PMC full-text retrieval, force PDF download",
     )
 
     # -- config --
@@ -438,6 +448,21 @@ async def _cmd_pdf(args: argparse.Namespace, config: object) -> int:
     else:
         output_dir = output_val
 
+    # When --convert is used and --no-fulltext is not set, try PMC full-text first
+    if args.convert and not args.no_fulltext:
+        async with PDFRetriever(config) as retriever:
+            md_path = await retriever.retrieve_as_markdown(
+                identifier=args.id,
+                output_dir=output_dir,
+                extract_images=True,
+                converter=args.converter,
+                filename=args.filename,
+            )
+        if md_path:
+            print(f"Retrieved: {md_path}", file=sys.stderr)
+            return 0
+        # If full text not available, fall through to PDF download
+
     async with PDFRetriever(config) as retriever:
         path = await retriever.download(
             identifier=args.id,
@@ -545,6 +570,7 @@ async def _cmd_batch_fetch(args: argparse.Namespace, config: object) -> int:
         convert=args.convert,
         converter=args.converter,
         concurrency=args.concurrency,
+        prefer_fulltext=not args.no_fulltext,
     )
 
     # Print summary
@@ -553,6 +579,12 @@ async def _cmd_batch_fetch(args: argparse.Namespace, config: object) -> int:
         file=sys.stderr,
         end="",
     )
+    if result.fulltext_retrieved:
+        print(
+            f" ({result.fulltext_retrieved} via PMC full text)",
+            file=sys.stderr,
+            end="",
+        )
     if args.convert:
         print(f", {result.converted} converted", file=sys.stderr, end="")
     if result.conversion_failed:

--- a/src/opencite/cli.py
+++ b/src/opencite/cli.py
@@ -448,7 +448,9 @@ async def _cmd_pdf(args: argparse.Namespace, config: object) -> int:
     else:
         output_dir = output_val
 
-    # When --convert is used and --no-fulltext is not set, try PMC full-text first
+    # When --convert is used and --no-fulltext is not set, try PMC full-text
+    # first then fall back to PDF download + convert (all handled inside
+    # retrieve_as_markdown).
     if args.convert and not args.no_fulltext:
         async with PDFRetriever(config) as retriever:
             md_path = await retriever.retrieve_as_markdown(
@@ -461,8 +463,10 @@ async def _cmd_pdf(args: argparse.Namespace, config: object) -> int:
         if md_path:
             print(f"Retrieved: {md_path}", file=sys.stderr)
             return 0
-        # If full text not available, fall through to PDF download
+        print("Could not retrieve full text or PDF.", file=sys.stderr)
+        return 1
 
+    # PDF-only download (no conversion, or --no-fulltext with conversion)
     async with PDFRetriever(config) as retriever:
         path = await retriever.download(
             identifier=args.id,
@@ -574,14 +578,16 @@ async def _cmd_batch_fetch(args: argparse.Namespace, config: object) -> int:
     )
 
     # Print summary
+    total_ok = result.downloaded + result.fulltext_retrieved
     print(
-        f"\nDone: {result.downloaded}/{result.total} downloaded",
+        f"\nDone: {total_ok}/{result.total} retrieved",
         file=sys.stderr,
         end="",
     )
     if result.fulltext_retrieved:
         print(
-            f" ({result.fulltext_retrieved} via PMC full text)",
+            f" ({result.fulltext_retrieved} via PMC full text,"
+            f" {result.downloaded} via PDF)",
             file=sys.stderr,
             end="",
         )

--- a/src/opencite/clients/pmc.py
+++ b/src/opencite/clients/pmc.py
@@ -60,10 +60,12 @@ class PMCClient(BaseClient):
 
     @staticmethod
     def _normalize_pmcid(pmcid: str) -> str:
-        """Ensure PMCID has the PMC prefix."""
+        """Ensure PMCID has the PMC prefix and is uppercase."""
         pmcid = pmcid.strip()
         if not pmcid.upper().startswith("PMC"):
             pmcid = f"PMC{pmcid}"
+        elif not pmcid.startswith("PMC"):
+            pmcid = "PMC" + pmcid[3:]
         return pmcid
 
     async def fetch_full_text(self, pmcid: str) -> dict | None:
@@ -84,7 +86,7 @@ class PMCClient(BaseClient):
         except APIError as e:
             logger.debug("BioC API error for %s: %s", pmcid, e)
             return None
-        except Exception as e:
+        except (httpx.HTTPError, ValueError, KeyError) as e:
             logger.debug("BioC fetch failed for %s: %s", pmcid, e)
             return None
 

--- a/src/opencite/clients/pmc.py
+++ b/src/opencite/clients/pmc.py
@@ -1,0 +1,207 @@
+"""PMC BioC and OA Web Service client."""
+
+from __future__ import annotations
+
+import logging
+import xml.etree.ElementTree as ET
+from pathlib import Path  # noqa: TC003 - used at runtime in fetch_image
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from opencite.clients.base import BaseClient
+from opencite.exceptions import APIError
+
+if TYPE_CHECKING:
+    from opencite.config import Config
+
+logger = logging.getLogger(__name__)
+
+_BIOC_BASE = "https://www.ncbi.nlm.nih.gov/research/bionlp/RESTful"
+_OA_BASE = "https://www.ncbi.nlm.nih.gov/pmc/utils/oa/oa.fcgi"
+_PMC_IMG_BASE = "https://pmc.ncbi.nlm.nih.gov/articles/instance"
+
+
+class PMCClient(BaseClient):
+    """Client for PMC BioC REST API and OA Web Service.
+
+    BioC API returns structured full-text JSON for PMC Open Access articles.
+    OA Web Service checks OA status and provides download links.
+    No API key required. Rate limit: 3 req/sec per PMC guidelines.
+    """
+
+    def __init__(self, config: Config):
+        super().__init__(
+            config=config,
+            base_url=_BIOC_BASE,
+            rate_limit=3.0,
+            burst=3,
+        )
+        self._oa_client: httpx.AsyncClient | None = None
+
+    async def __aenter__(self) -> PMCClient:
+        await super().__aenter__()
+        self._oa_client = httpx.AsyncClient(timeout=self.timeout)
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        if self._oa_client:
+            await self._oa_client.aclose()
+            self._oa_client = None
+        await super().__aexit__(*args)
+
+    def _default_headers(self) -> dict[str, str]:
+        headers: dict[str, str] = {
+            "Accept": "application/json",
+        }
+        if self.config.pubmed_api_key:
+            headers["api_key"] = self.config.pubmed_api_key
+        return headers
+
+    @staticmethod
+    def _normalize_pmcid(pmcid: str) -> str:
+        """Ensure PMCID has the PMC prefix."""
+        pmcid = pmcid.strip()
+        if not pmcid.upper().startswith("PMC"):
+            pmcid = f"PMC{pmcid}"
+        return pmcid
+
+    async def fetch_full_text(self, pmcid: str) -> dict | None:
+        """Fetch structured full-text from the BioC API.
+
+        Args:
+            pmcid: PubMed Central ID (e.g. "PMC5334499").
+
+        Returns:
+            BioC document dict with passages, or None if not available.
+        """
+        pmcid = self._normalize_pmcid(pmcid)
+        path = f"/pmcoa.cgi/BioC_json/{pmcid}/unicode"
+
+        try:
+            resp = await self.get(path)
+            data = resp.json()
+        except APIError as e:
+            logger.debug("BioC API error for %s: %s", pmcid, e)
+            return None
+        except Exception as e:
+            logger.debug("BioC fetch failed for %s: %s", pmcid, e)
+            return None
+
+        if not isinstance(data, list) or not data:
+            logger.debug("BioC returned empty or non-list for %s", pmcid)
+            return None
+
+        collection = data[0]
+        documents = collection.get("documents", [])
+        if not documents:
+            logger.debug("BioC returned no documents for %s", pmcid)
+            return None
+
+        return documents[0]
+
+    async def check_oa_status(self, pmcid: str) -> dict | None:
+        """Check if an article is in the PMC Open Access subset.
+
+        Args:
+            pmcid: PubMed Central ID (e.g. "PMC5334499").
+
+        Returns:
+            Dict with keys: id, citation, license, retracted, links (list of
+            dicts with format, href, updated). None if not OA.
+        """
+        if self._oa_client is None:
+            raise RuntimeError("Client not initialized. Use 'async with'.")
+
+        pmcid = self._normalize_pmcid(pmcid)
+        url = f"{_OA_BASE}?id={pmcid}"
+
+        try:
+            resp = await self._oa_client.get(url)
+            resp.raise_for_status()
+        except httpx.HTTPError as e:
+            logger.debug("OA status check failed for %s: %s", pmcid, e)
+            return None
+
+        try:
+            root = ET.fromstring(resp.text)
+        except ET.ParseError:
+            logger.debug("Failed to parse OA XML for %s", pmcid)
+            return None
+
+        error = root.find("error")
+        if error is not None:
+            logger.debug("OA API: %s (%s)", error.text, error.get("code", ""))
+            return None
+
+        records = root.find("records")
+        if records is None:
+            return None
+
+        record = records.find("record")
+        if record is None:
+            return None
+
+        links = []
+        for link_el in record.findall("link"):
+            links.append(
+                {
+                    "format": link_el.get("format", ""),
+                    "href": link_el.get("href", ""),
+                    "updated": link_el.get("updated", ""),
+                }
+            )
+
+        return {
+            "id": record.get("id", pmcid),
+            "citation": record.get("citation", ""),
+            "license": record.get("license", ""),
+            "retracted": record.get("retracted", "no") == "yes",
+            "links": links,
+        }
+
+    async def fetch_image(
+        self,
+        pmcid: str,
+        filename: str,
+        dest: Path,
+    ) -> Path | None:
+        """Download a figure image from a PMC article.
+
+        Tries the PMC instance URL pattern for article images.
+
+        Args:
+            pmcid: PubMed Central ID.
+            filename: Image filename from BioC data (e.g. "WJR-9-27-g001.jpg").
+            dest: Local path to save the image.
+
+        Returns:
+            Path to saved image, or None if download fails.
+        """
+        if self._oa_client is None:
+            raise RuntimeError("Client not initialized. Use 'async with'.")
+
+        pmcid = self._normalize_pmcid(pmcid)
+        url = f"{_PMC_IMG_BASE}/{pmcid}/bin/{filename}"
+
+        try:
+            resp = await self._oa_client.get(url, follow_redirects=True)
+            resp.raise_for_status()
+
+            content_type = resp.headers.get("content-type", "")
+            if "image" not in content_type and "octet-stream" not in content_type:
+                logger.debug(
+                    "PMC image response not an image: %s (%s)",
+                    filename,
+                    content_type,
+                )
+                return None
+
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(resp.content)
+            logger.debug("Downloaded PMC image: %s -> %s", filename, dest)
+            return dest
+
+        except httpx.HTTPError as e:
+            logger.debug("PMC image download failed for %s: %s", filename, e)
+            return None

--- a/src/opencite/fulltext.py
+++ b/src/opencite/fulltext.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import logging
-import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import httpx
+
 from opencite.clients.id_converter import IDConverterClient
 from opencite.clients.pmc import PMCClient
+from opencite.exceptions import OpenCiteError
 from opencite.models import IDType, Paper, parse_identifier
 from opencite.pmc_convert import bioc_to_markdown, extract_figure_files
 
@@ -28,8 +30,8 @@ class FullTextRetriever:
     Retrieval flow:
     1. Resolve PMCID (from paper metadata or ID converter)
     2. Fetch structured text via BioC API
-    3. Convert BioC passages to markdown
-    4. Optionally download figure images
+    3. Optionally download figure images
+    4. Convert BioC passages to markdown
     5. Write markdown to output file
     """
 
@@ -144,7 +146,7 @@ class FullTextRetriever:
             for ids in id_sets:
                 if ids.pmcid:
                     return ids.pmcid
-        except Exception as e:
+        except (OpenCiteError, httpx.HTTPError, ValueError) as e:
             logger.debug("ID conversion failed for %s: %s", identifier, e)
 
         return None
@@ -165,18 +167,6 @@ class FullTextRetriever:
 
     def _make_filename(self, paper: Paper | None, identifier: str) -> str:
         """Generate a filename from paper metadata."""
-        if paper and paper.title:
-            author = ""
-            if paper.authors:
-                a = paper.authors[0]
-                author = a.family_name or a.name.split(",")[0].strip()
-                author = re.sub(r"[^\w]", "", author)
+        from opencite.utils import make_paper_filename
 
-            year = paper.year_str
-            words = paper.title.split()[:3]
-            title_part = "_".join(re.sub(r"[^\w]", "", w) for w in words)
-            parts = [p for p in [author, year, title_part] if p]
-            return "_".join(parts)
-
-        safe = re.sub(r"[^\w.-]", "_", identifier)
-        return safe
+        return make_paper_filename(paper, identifier)

--- a/src/opencite/fulltext.py
+++ b/src/opencite/fulltext.py
@@ -1,0 +1,182 @@
+"""Full-text retrieval pipeline using PMC BioC API."""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from opencite.clients.id_converter import IDConverterClient
+from opencite.clients.pmc import PMCClient
+from opencite.models import IDType, Paper, parse_identifier
+from opencite.pmc_convert import bioc_to_markdown, extract_figure_files
+
+if TYPE_CHECKING:
+    from opencite.config import Config
+
+logger = logging.getLogger(__name__)
+
+
+class FullTextRetriever:
+    """Retrieve full-text articles from PMC and convert to markdown.
+
+    Uses the PMC BioC API for structured article content and downloads
+    figure images when available. Only works for articles in the PMC
+    Open Access subset.
+
+    Retrieval flow:
+    1. Resolve PMCID (from paper metadata or ID converter)
+    2. Fetch structured text via BioC API
+    3. Convert BioC passages to markdown
+    4. Optionally download figure images
+    5. Write markdown to output file
+    """
+
+    def __init__(self, config: Config):
+        self.config = config
+        self._pmc = PMCClient(config)
+        self._id_converter = IDConverterClient(config)
+
+    async def __aenter__(self) -> FullTextRetriever:
+        await self._pmc.__aenter__()
+        await self._id_converter.__aenter__()
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        await self._id_converter.__aexit__()
+        await self._pmc.__aexit__()
+
+    async def retrieve(
+        self,
+        identifier: str,
+        output_dir: str = ".",
+        paper: Paper | None = None,
+        extract_images: bool = True,
+        filename: str | None = None,
+    ) -> Path | None:
+        """Retrieve full-text markdown for a paper from PMC.
+
+        Args:
+            identifier: DOI, PMID, PMCID, or other paper identifier.
+            output_dir: Directory to save the markdown file.
+            paper: Pre-fetched Paper object (avoids extra lookup).
+            extract_images: Whether to download figure images.
+            filename: Custom filename (without extension) for the output.
+
+        Returns:
+            Path to the markdown file, or None if full text is not available.
+        """
+        # Step 1: Resolve PMCID
+        pmcid = self._resolve_pmcid(identifier, paper)
+        if not pmcid:
+            pmcid = await self._lookup_pmcid(identifier)
+        if not pmcid:
+            logger.debug("No PMCID found for %s; full text not available", identifier)
+            return None
+
+        # Step 2: Fetch BioC full text
+        document = await self._pmc.fetch_full_text(pmcid)
+        if document is None:
+            logger.debug("BioC full text not available for %s", pmcid)
+            return None
+
+        # Step 3: Set up output paths
+        out_dir = Path(output_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        fname = filename or self._make_filename(paper, identifier)
+        if not fname.endswith(".md"):
+            fname += ".md"
+        md_path = out_dir / fname
+
+        # Step 4: Optionally download images
+        images_subdir: str | None = None
+        if extract_images:
+            figures = extract_figure_files(document)
+            if figures:
+                img_dir_name = Path(fname).stem
+                img_dir = out_dir / "img" / img_dir_name
+                images_subdir = f"img/{img_dir_name}"
+                await self._download_images(pmcid, figures, img_dir)
+
+        # Step 5: Convert to markdown
+        md_text = bioc_to_markdown(document, images_dir=images_subdir)
+
+        # Step 6: Write output
+        md_path.write_text(md_text, encoding="utf-8")
+        logger.info("Full text written to %s", md_path)
+        return md_path
+
+    def _resolve_pmcid(self, identifier: str, paper: Paper | None) -> str | None:
+        """Try to get PMCID from paper metadata or identifier string."""
+        if paper and paper.pmcid:
+            return paper.pmcid
+
+        # Check if identifier itself is a PMCID
+        try:
+            id_type, id_value = parse_identifier(identifier)
+            if id_type == IDType.PMCID:
+                return id_value
+        except ValueError:
+            pass
+
+        # Check for bare PMC format
+        stripped = identifier.strip().upper()
+        if stripped.startswith("PMC") and stripped[3:].isdigit():
+            return stripped
+
+        return None
+
+    async def _lookup_pmcid(self, identifier: str) -> str | None:
+        """Look up PMCID via the NCBI ID Converter."""
+        try:
+            id_type, id_value = parse_identifier(identifier)
+        except ValueError:
+            return None
+
+        if id_type == IDType.PMCID:
+            return id_value
+
+        # Convert DOI or PMID to PMCID
+        try:
+            id_sets = await self._id_converter.convert([identifier])
+            for ids in id_sets:
+                if ids.pmcid:
+                    return ids.pmcid
+        except Exception as e:
+            logger.debug("ID conversion failed for %s: %s", identifier, e)
+
+        return None
+
+    async def _download_images(
+        self,
+        pmcid: str,
+        figures: list[tuple[str, str]],
+        img_dir: Path,
+    ) -> None:
+        """Download figure images for an article."""
+        img_dir.mkdir(parents=True, exist_ok=True)
+        for _fig_id, fig_file in figures:
+            dest = img_dir / fig_file
+            result = await self._pmc.fetch_image(pmcid, fig_file, dest)
+            if result is None:
+                logger.debug("Could not download image %s for %s", fig_file, pmcid)
+
+    def _make_filename(self, paper: Paper | None, identifier: str) -> str:
+        """Generate a filename from paper metadata."""
+        if paper and paper.title:
+            author = ""
+            if paper.authors:
+                a = paper.authors[0]
+                author = a.family_name or a.name.split(",")[0].strip()
+                author = re.sub(r"[^\w]", "", author)
+
+            year = paper.year_str
+            words = paper.title.split()[:3]
+            title_part = "_".join(re.sub(r"[^\w]", "", w) for w in words)
+            parts = [p for p in [author, year, title_part] if p]
+            return "_".join(parts)
+
+        safe = re.sub(r"[^\w.-]", "_", identifier)
+        return safe

--- a/src/opencite/pdf.py
+++ b/src/opencite/pdf.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -50,8 +49,9 @@ class PDFRetriever:
     Retrieval priority:
     1. Publisher-authenticated URLs (if tokens available)
     2. Paper's known PDF locations (OpenAlex, S2)
-    3. PMC OA Service (if PMCID available or discoverable)
-    4. DOI content negotiation
+    3. Direct arXiv/bioRxiv/medRxiv PDF URLs
+    4. PMC OA Service (if PMCID available or discoverable)
+    5. DOI content negotiation
 
     When the caller wants markdown (retrieve_as_markdown), the retriever
     first tries PMC full-text retrieval to skip the PDF step entirely.
@@ -368,26 +368,12 @@ class PDFRetriever:
                 mistral_api_key=self.config.mistral_api_key,
             )
             return md_out
-        except Exception as e:
+        except (OSError, ValueError, ImportError) as e:
             logger.warning("PDF conversion failed for %s: %s", identifier, e)
             return None
 
     def _make_filename(self, paper: Paper | None, identifier: str) -> str:
         """Generate a filename from paper metadata."""
-        if paper and paper.title:
-            # first_author_year_firstwords
-            author = ""
-            if paper.authors:
-                a = paper.authors[0]
-                author = a.family_name or a.name.split(",")[0].strip()
-                author = re.sub(r"[^\w]", "", author)
+        from opencite.utils import make_paper_filename
 
-            year = paper.year_str
-            words = paper.title.split()[:3]
-            title_part = "_".join(re.sub(r"[^\w]", "", w) for w in words)
-            parts = [p for p in [author, year, title_part] if p]
-            return "_".join(parts)
-
-        # Fallback: sanitize identifier
-        safe = re.sub(r"[^\w.-]", "_", identifier)
-        return safe
+        return make_paper_filename(paper, identifier)

--- a/src/opencite/pdf.py
+++ b/src/opencite/pdf.py
@@ -52,6 +52,9 @@ class PDFRetriever:
     2. Paper's known PDF locations (OpenAlex, S2)
     3. PMC OA Service (if PMCID available or discoverable)
     4. DOI content negotiation
+
+    When the caller wants markdown (retrieve_as_markdown), the retriever
+    first tries PMC full-text retrieval to skip the PDF step entirely.
     """
 
     def __init__(self, config: Config):
@@ -298,6 +301,76 @@ class PDFRetriever:
                 "Paper may be available via institutional access: https://doi.org/%s",
                 doi,
             )
+
+    async def retrieve_as_markdown(
+        self,
+        identifier: str,
+        output_dir: str = ".",
+        paper: Paper | None = None,
+        extract_images: bool = True,
+        converter: str = "auto",
+        filename: str | None = None,
+    ) -> Path | None:
+        """Try PMC full-text first, then fall back to PDF download + convert.
+
+        Args:
+            identifier: DOI or other paper identifier.
+            output_dir: Directory to save output (markdown and optional images).
+            paper: Pre-fetched Paper object.
+            extract_images: Whether to extract/download images.
+            converter: Converter for PDF fallback ("auto", "markitdown", "mistral").
+            filename: Custom base filename (without extension).
+
+        Returns:
+            Path to the markdown file, or None if all methods fail.
+        """
+        from opencite.fulltext import FullTextRetriever
+
+        # If no paper provided, try to get metadata
+        if paper is None:
+            paper = await self._quick_lookup(identifier)
+
+        # Try PMC full-text first
+        async with FullTextRetriever(self.config) as ft:
+            md_path = await ft.retrieve(
+                identifier=identifier,
+                output_dir=output_dir,
+                paper=paper,
+                extract_images=extract_images,
+                filename=filename,
+            )
+            if md_path:
+                logger.info("Retrieved full text from PMC for %s", identifier)
+                return md_path
+
+        # Fall back to PDF download + conversion
+        logger.debug("PMC full text not available for %s, trying PDF", identifier)
+        pdf_path = await self.download(
+            identifier=identifier,
+            output_dir=output_dir,
+            paper=paper,
+            filename=filename,
+        )
+
+        if pdf_path is None:
+            return None
+
+        # Convert PDF to markdown
+        from opencite.convert import convert_pdf
+
+        md_out = pdf_path.with_suffix(".md")
+        try:
+            convert_pdf(
+                str(pdf_path),
+                output_path=str(md_out),
+                converter=converter,
+                extract_images=extract_images,
+                mistral_api_key=self.config.mistral_api_key,
+            )
+            return md_out
+        except Exception as e:
+            logger.warning("PDF conversion failed for %s: %s", identifier, e)
+            return None
 
     def _make_filename(self, paper: Paper | None, identifier: str) -> str:
         """Generate a filename from paper metadata."""

--- a/src/opencite/pmc_convert.py
+++ b/src/opencite/pmc_convert.py
@@ -1,0 +1,260 @@
+"""Convert PMC BioC JSON to markdown."""
+
+from __future__ import annotations
+
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+# Map BioC section_type to default markdown heading
+_SECTION_HEADINGS: dict[str, str] = {
+    "INTRO": "Introduction",
+    "METHODS": "Methods",
+    "RESULTS": "Results",
+    "DISCUSS": "Discussion",
+    "CONCL": "Conclusion",
+    "ABSTRACT": "Abstract",
+    "SUPPL": "Supplementary Material",
+    "ACK_FUND": "Acknowledgments",
+    "COMP_INT": "Competing Interests",
+    "AUTH_CONT": "Author Contributions",
+    "ABBR": "Abbreviations",
+    "APPENDIX": "Appendix",
+    "CASE": "Case Report",
+    "REF": "References",
+}
+
+
+def bioc_to_markdown(
+    document: dict,
+    images_dir: str | None = None,
+) -> str:
+    """Convert a BioC document to markdown.
+
+    Args:
+        document: A BioC document dict (the element inside
+            collection.documents[0]). Must have a "passages" list.
+        images_dir: Relative path prefix for image references in markdown.
+            If None, images are referenced by filename only.
+
+    Returns:
+        Markdown-formatted text.
+    """
+    passages = document.get("passages", [])
+    if not passages:
+        return ""
+
+    parts: list[str] = []
+    current_section: str = ""
+    seen_section_titles: set[str] = set()
+
+    for passage in passages:
+        infons = passage.get("infons", {})
+        section_type = infons.get("section_type", "")
+        ptype = infons.get("type", "")
+        text = passage.get("text", "").strip()
+
+        if not text:
+            continue
+
+        # Title (article title)
+        if ptype == "front" and section_type == "TITLE":
+            parts.append(f"# {text}\n")
+            continue
+
+        # Section headings from the article structure
+        if ptype in ("title", "title_1"):
+            # Major section heading
+            if section_type != current_section:
+                current_section = section_type
+            heading = text
+            if heading not in seen_section_titles:
+                seen_section_titles.add(heading)
+                parts.append(f"## {heading}\n")
+            continue
+
+        if ptype == "title_2":
+            parts.append(f"### {text}\n")
+            continue
+
+        if ptype == "title_3":
+            parts.append(f"#### {text}\n")
+            continue
+
+        # Abstract: emit section heading if we haven't yet
+        if section_type == "ABSTRACT" and ptype == "abstract":
+            if "Abstract" not in seen_section_titles:
+                seen_section_titles.add("Abstract")
+                parts.append("## Abstract\n")
+            parts.append(f"{text}\n")
+            continue
+
+        # For body sections, emit a default heading if no explicit title seen
+        if (
+            section_type in _SECTION_HEADINGS
+            and section_type != current_section
+            and ptype == "paragraph"
+        ):
+            heading = _SECTION_HEADINGS[section_type]
+            if heading not in seen_section_titles:
+                seen_section_titles.add(heading)
+                parts.append(f"## {heading}\n")
+            current_section = section_type
+
+        # Figures
+        if ptype in ("fig_caption", "fig_title_caption"):
+            fig_file = infons.get("file", "")
+            fig_id = infons.get("id", "")
+
+            if fig_file and _is_image_file(fig_file):
+                img_path = f"{images_dir}/{fig_file}" if images_dir else fig_file
+                caption = text
+                label = f"**Figure {fig_id}**: " if fig_id else ""
+                parts.append(f"![{fig_id or 'figure'}]({img_path})\n")
+                parts.append(f"{label}{caption}\n")
+            else:
+                label = f"**Figure {fig_id}**: " if fig_id else ""
+                parts.append(f"{label}{text}\n")
+            continue
+
+        # Tables
+        if ptype in ("table_caption", "table_title_caption"):
+            table_id = infons.get("id", "")
+            label = f"**Table {table_id}**: " if table_id else ""
+            parts.append(f"{label}{text}\n")
+            continue
+
+        if ptype == "table":
+            parts.append(_format_table_text(text))
+            continue
+
+        if ptype == "table_footnote":
+            parts.append(f"*{text}*\n")
+            continue
+
+        # References
+        if section_type == "REF" and ptype == "ref":
+            if "References" not in seen_section_titles:
+                seen_section_titles.add("References")
+                parts.append("## References\n")
+                current_section = "REF"
+            parts.append(f"- {text}\n")
+            continue
+
+        # Footnotes
+        if ptype == "footnote":
+            parts.append(f"> {text}\n")
+            continue
+
+        # Regular paragraphs
+        if ptype == "paragraph":
+            parts.append(f"{text}\n")
+            continue
+
+        # Fallback: include unrecognized passage types as plain text
+        if text and ptype not in ("front",):
+            parts.append(f"{text}\n")
+
+    return "\n".join(parts).strip() + "\n"
+
+
+def extract_figure_files(document: dict) -> list[tuple[str, str]]:
+    """Extract figure file references from a BioC document.
+
+    Args:
+        document: A BioC document dict.
+
+    Returns:
+        List of (figure_id, filename) tuples for image files.
+    """
+    figures: list[tuple[str, str]] = []
+    seen: set[str] = set()
+
+    for passage in document.get("passages", []):
+        infons = passage.get("infons", {})
+        fig_file = infons.get("file", "")
+        fig_id = infons.get("id", "")
+
+        if fig_file and _is_image_file(fig_file) and fig_file not in seen:
+            seen.add(fig_file)
+            figures.append((fig_id, fig_file))
+
+    return figures
+
+
+def extract_metadata(document: dict) -> dict:
+    """Extract article metadata from the BioC front matter passage.
+
+    Args:
+        document: A BioC document dict.
+
+    Returns:
+        Dict with keys like doi, pmid, pmcid, year, license, authors, etc.
+    """
+    for passage in document.get("passages", []):
+        infons = passage.get("infons", {})
+        if infons.get("type") == "front":
+            meta: dict = {}
+            meta["doi"] = infons.get("article-id_doi", "")
+            meta["pmcid"] = infons.get("article-id_pmc", "")
+            meta["pmid"] = infons.get("article-id_pmid", "")
+            meta["year"] = infons.get("year", "")
+            meta["volume"] = infons.get("volume", "")
+            meta["issue"] = infons.get("issue", "")
+            meta["license"] = infons.get("license", "")
+            meta["title"] = passage.get("text", "")
+
+            # Extract authors from name_N keys
+            authors = []
+            for i in range(100):
+                name_key = f"name_{i}"
+                if name_key not in infons:
+                    break
+                authors.append(infons[name_key])
+            meta["authors"] = authors
+
+            return meta
+
+    return {}
+
+
+def _is_image_file(filename: str) -> bool:
+    """Check if a filename is an image (not XML or other data)."""
+    return bool(
+        re.search(r"\.(jpg|jpeg|png|gif|svg|tiff|tif|bmp|webp)$", filename, re.I)
+    )
+
+
+def _format_table_text(text: str) -> str:
+    """Format tab-separated table text as markdown table."""
+    if not text.strip():
+        return ""
+    lines = text.strip().split("\n")
+
+    rows: list[list[str]] = []
+    for line in lines:
+        # BioC tables use tab separation
+        cells = line.split("\t")
+        rows.append([c.strip() for c in cells])
+
+    if not rows:
+        return ""
+
+    # Find max columns
+    max_cols = max(len(r) for r in rows)
+    # Pad rows to same width
+    for row in rows:
+        while len(row) < max_cols:
+            row.append("")
+
+    # Build markdown table
+    parts: list[str] = []
+    # Header row
+    parts.append("| " + " | ".join(rows[0]) + " |")
+    parts.append("| " + " | ".join("---" for _ in rows[0]) + " |")
+    # Data rows
+    for row in rows[1:]:
+        parts.append("| " + " | ".join(row) + " |")
+
+    return "\n".join(parts) + "\n"

--- a/src/opencite/utils.py
+++ b/src/opencite/utils.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 import unicodedata
 
-from opencite.models import Author
+from opencite.models import Author, Paper
 
 
 def normalize_title(title: str) -> set[str]:
@@ -65,3 +65,22 @@ def reconstruct_abstract(inverted_index: dict | None) -> str:
         for pos in positions:
             words[pos] = word
     return " ".join(w for w in words if w)
+
+
+def make_paper_filename(paper: Paper | None, identifier: str) -> str:
+    """Generate a filename stem from paper metadata or identifier."""
+    if paper and paper.title:
+        author = ""
+        if paper.authors:
+            a = paper.authors[0]
+            author = a.family_name or a.name.split(",")[0].strip()
+            author = re.sub(r"[^\w]", "", author)
+
+        year = paper.year_str
+        words = paper.title.split()[:3]
+        title_part = "_".join(re.sub(r"[^\w]", "", w) for w in words)
+        parts = [p for p in [author, year, title_part] if p]
+        return "_".join(parts)
+
+    safe = re.sub(r"[^\w.-]", "_", identifier)
+    return safe

--- a/tests/test_fulltext.py
+++ b/tests/test_fulltext.py
@@ -1,0 +1,68 @@
+"""Tests for full-text retrieval pipeline."""
+
+from __future__ import annotations
+
+from opencite.fulltext import FullTextRetriever
+from opencite.models import IDSet, Paper
+
+
+class TestResolvePmcid:
+    def _make_retriever(self):
+        retriever = FullTextRetriever.__new__(FullTextRetriever)
+        return retriever
+
+    def test_from_paper_pmcid(self):
+        retriever = self._make_retriever()
+        paper = Paper(title="Test", ids=IDSet(pmcid="PMC12345"))
+        assert retriever._resolve_pmcid("10.1234/test", paper) == "PMC12345"
+
+    def test_from_identifier_pmcid(self):
+        retriever = self._make_retriever()
+        assert retriever._resolve_pmcid("pmc:12345", None) == "PMC12345"
+
+    def test_bare_pmcid(self):
+        retriever = self._make_retriever()
+        assert retriever._resolve_pmcid("PMC12345", None) == "PMC12345"
+
+    def test_doi_returns_none(self):
+        retriever = self._make_retriever()
+        assert retriever._resolve_pmcid("10.1234/test", None) is None
+
+    def test_paper_without_pmcid(self):
+        retriever = self._make_retriever()
+        paper = Paper(title="Test", ids=IDSet(doi="10.1234/test"))
+        assert retriever._resolve_pmcid("10.1234/test", paper) is None
+
+    def test_invalid_identifier(self):
+        retriever = self._make_retriever()
+        assert retriever._resolve_pmcid("not_valid", None) is None
+
+
+class TestMakeFilename:
+    def _make_retriever(self):
+        retriever = FullTextRetriever.__new__(FullTextRetriever)
+        return retriever
+
+    def test_with_paper_metadata(self):
+        from opencite.models import Author
+
+        retriever = self._make_retriever()
+        paper = Paper(
+            title="Attention Is All You Need",
+            authors=[Author(name="Vaswani", family_name="Vaswani")],
+            year=2017,
+        )
+        name = retriever._make_filename(paper, "10.xxx")
+        assert "Vaswani" in name
+        assert "2017" in name
+        assert "Attention" in name
+
+    def test_without_paper(self):
+        retriever = self._make_retriever()
+        name = retriever._make_filename(None, "10.1234/test")
+        assert "10.1234" in name or "10_1234" in name
+
+    def test_sanitizes_special_chars(self):
+        retriever = self._make_retriever()
+        name = retriever._make_filename(None, "10.1234/some.test/thing")
+        assert "/" not in name

--- a/tests/test_pmc_client.py
+++ b/tests/test_pmc_client.py
@@ -1,0 +1,39 @@
+"""Tests for the PMC BioC client."""
+
+from __future__ import annotations
+
+from opencite.clients.pmc import PMCClient
+
+
+class TestNormalizePmcid:
+    def test_with_prefix(self):
+        assert PMCClient._normalize_pmcid("PMC5334499") == "PMC5334499"
+
+    def test_without_prefix(self):
+        assert PMCClient._normalize_pmcid("5334499") == "PMC5334499"
+
+    def test_lowercase_prefix(self):
+        assert PMCClient._normalize_pmcid("pmc5334499") == "pmc5334499"
+
+    def test_with_whitespace(self):
+        assert PMCClient._normalize_pmcid("  PMC5334499  ") == "PMC5334499"
+
+
+class TestDefaultHeaders:
+    def _make_client(self, **config_kwargs):
+        from opencite.config import Config
+
+        client = PMCClient.__new__(PMCClient)
+        client.config = Config(**config_kwargs)
+        return client
+
+    def test_headers_with_no_api_key(self):
+        client = self._make_client()
+        headers = client._default_headers()
+        assert headers["Accept"] == "application/json"
+        assert "api_key" not in headers
+
+    def test_headers_with_pubmed_api_key(self):
+        client = self._make_client(pubmed_api_key="test-key")
+        headers = client._default_headers()
+        assert headers["api_key"] == "test-key"

--- a/tests/test_pmc_client.py
+++ b/tests/test_pmc_client.py
@@ -13,7 +13,10 @@ class TestNormalizePmcid:
         assert PMCClient._normalize_pmcid("5334499") == "PMC5334499"
 
     def test_lowercase_prefix(self):
-        assert PMCClient._normalize_pmcid("pmc5334499") == "pmc5334499"
+        assert PMCClient._normalize_pmcid("pmc5334499") == "PMC5334499"
+
+    def test_mixed_case_prefix(self):
+        assert PMCClient._normalize_pmcid("Pmc5334499") == "PMC5334499"
 
     def test_with_whitespace(self):
         assert PMCClient._normalize_pmcid("  PMC5334499  ") == "PMC5334499"

--- a/tests/test_pmc_convert.py
+++ b/tests/test_pmc_convert.py
@@ -1,0 +1,441 @@
+"""Tests for BioC JSON to markdown conversion."""
+
+from __future__ import annotations
+
+from opencite.pmc_convert import (
+    _format_table_text,
+    _is_image_file,
+    bioc_to_markdown,
+    extract_figure_files,
+    extract_metadata,
+)
+
+
+def _make_passage(
+    text: str,
+    section_type: str = "",
+    ptype: str = "paragraph",
+    **extra_infons: str,
+) -> dict:
+    """Helper to create a BioC passage dict."""
+    infons = {"section_type": section_type, "type": ptype}
+    infons.update(extra_infons)
+    return {
+        "infons": infons,
+        "text": text,
+        "sentences": [],
+        "annotations": [],
+        "relations": [],
+    }
+
+
+def _make_document(passages: list[dict]) -> dict:
+    """Wrap passages in a document dict."""
+    return {"id": "PMC12345", "infons": {}, "passages": passages}
+
+
+class TestBiocToMarkdown:
+    def test_empty_document(self):
+        doc = _make_document([])
+        assert bioc_to_markdown(doc) == ""
+
+    def test_title_only(self):
+        doc = _make_document(
+            [
+                _make_passage("My Article Title", section_type="TITLE", ptype="front"),
+            ]
+        )
+        md = bioc_to_markdown(doc)
+        assert md.startswith("# My Article Title")
+
+    def test_abstract(self):
+        doc = _make_document(
+            [
+                _make_passage("My Article", section_type="TITLE", ptype="front"),
+                _make_passage(
+                    "This is the abstract.", section_type="ABSTRACT", ptype="abstract"
+                ),
+            ]
+        )
+        md = bioc_to_markdown(doc)
+        assert "## Abstract" in md
+        assert "This is the abstract." in md
+
+    def test_intro_with_explicit_heading(self):
+        doc = _make_document(
+            [
+                _make_passage("Background", section_type="INTRO", ptype="title_1"),
+                _make_passage(
+                    "Some intro text.", section_type="INTRO", ptype="paragraph"
+                ),
+            ]
+        )
+        md = bioc_to_markdown(doc)
+        assert "## Background" in md
+        assert "Some intro text." in md
+
+    def test_intro_with_default_heading(self):
+        doc = _make_document(
+            [
+                _make_passage(
+                    "Some intro text.", section_type="INTRO", ptype="paragraph"
+                ),
+            ]
+        )
+        md = bioc_to_markdown(doc)
+        assert "## Introduction" in md
+
+    def test_subsection_heading(self):
+        doc = _make_document(
+            [
+                _make_passage("Methods", section_type="METHODS", ptype="title_1"),
+                _make_passage("Sub-section", section_type="METHODS", ptype="title_2"),
+                _make_passage("Details.", section_type="METHODS", ptype="paragraph"),
+            ]
+        )
+        md = bioc_to_markdown(doc)
+        assert "## Methods" in md
+        assert "### Sub-section" in md
+        assert "Details." in md
+
+    def test_figure_with_image(self):
+        doc = _make_document(
+            [
+                _make_passage(
+                    "A schematic of the system.",
+                    section_type="FIG",
+                    ptype="fig_caption",
+                    file="fig1.jpg",
+                    id="F1",
+                ),
+            ]
+        )
+        md = bioc_to_markdown(doc)
+        assert "![F1](fig1.jpg)" in md
+        assert "**Figure F1**:" in md
+        assert "A schematic of the system." in md
+
+    def test_figure_with_images_dir(self):
+        doc = _make_document(
+            [
+                _make_passage(
+                    "Caption.",
+                    section_type="FIG",
+                    ptype="fig_caption",
+                    file="fig1.png",
+                    id="F1",
+                ),
+            ]
+        )
+        md = bioc_to_markdown(doc, images_dir="img/paper1")
+        assert "![F1](img/paper1/fig1.png)" in md
+
+    def test_figure_with_xml_file_no_image(self):
+        doc = _make_document(
+            [
+                _make_passage(
+                    "Table data.",
+                    section_type="FIG",
+                    ptype="fig_caption",
+                    file="table.xml",
+                    id="T1",
+                ),
+            ]
+        )
+        md = bioc_to_markdown(doc)
+        assert "![" not in md
+        assert "Table data." in md
+
+    def test_table_caption(self):
+        doc = _make_document(
+            [
+                _make_passage(
+                    "Patient demographics.",
+                    section_type="TABLE",
+                    ptype="table_caption",
+                    id="T1",
+                ),
+            ]
+        )
+        md = bioc_to_markdown(doc)
+        assert "**Table T1**:" in md
+
+    def test_table_content(self):
+        doc = _make_document(
+            [
+                _make_passage(
+                    "Name\tAge\tStatus\nAlice\t30\tActive",
+                    section_type="TABLE",
+                    ptype="table",
+                ),
+            ]
+        )
+        md = bioc_to_markdown(doc)
+        assert "| Name | Age | Status |" in md
+        assert "| Alice | 30 | Active |" in md
+        assert "| --- | --- | --- |" in md
+
+    def test_references(self):
+        doc = _make_document(
+            [
+                _make_passage(
+                    "Smith J. et al. (2020). Title. Journal.",
+                    section_type="REF",
+                    ptype="ref",
+                ),
+                _make_passage(
+                    "Doe A. et al. (2019). Title. Journal.",
+                    section_type="REF",
+                    ptype="ref",
+                ),
+            ]
+        )
+        md = bioc_to_markdown(doc)
+        assert "## References" in md
+        assert "- Smith J. et al." in md
+        assert "- Doe A. et al." in md
+
+    def test_references_heading_not_duplicated(self):
+        doc = _make_document(
+            [
+                _make_passage("Ref 1.", section_type="REF", ptype="ref"),
+                _make_passage("Ref 2.", section_type="REF", ptype="ref"),
+            ]
+        )
+        md = bioc_to_markdown(doc)
+        assert md.count("## References") == 1
+
+    def test_footnote(self):
+        doc = _make_document(
+            [
+                _make_passage(
+                    "This is a footnote.", section_type="INTRO", ptype="footnote"
+                ),
+            ]
+        )
+        md = bioc_to_markdown(doc)
+        assert "> This is a footnote." in md
+
+    def test_multiple_sections(self):
+        doc = _make_document(
+            [
+                _make_passage("Title", section_type="TITLE", ptype="front"),
+                _make_passage(
+                    "Abstract text.", section_type="ABSTRACT", ptype="abstract"
+                ),
+                _make_passage("Introduction", section_type="INTRO", ptype="title_1"),
+                _make_passage("Intro text.", section_type="INTRO", ptype="paragraph"),
+                _make_passage("Methods", section_type="METHODS", ptype="title_1"),
+                _make_passage(
+                    "Methods text.", section_type="METHODS", ptype="paragraph"
+                ),
+                _make_passage("Results", section_type="RESULTS", ptype="title_1"),
+                _make_passage(
+                    "Results text.", section_type="RESULTS", ptype="paragraph"
+                ),
+            ]
+        )
+        md = bioc_to_markdown(doc)
+        lines = md.split("\n")
+        # Check section order
+        headings = [line for line in lines if line.startswith("#")]
+        assert headings[0] == "# Title"
+        assert "## Abstract" in headings
+        assert "## Introduction" in headings
+        assert "## Methods" in headings
+        assert "## Results" in headings
+
+    def test_empty_text_passages_skipped(self):
+        doc = _make_document(
+            [
+                _make_passage("", section_type="INTRO", ptype="paragraph"),
+                _make_passage("  ", section_type="INTRO", ptype="paragraph"),
+                _make_passage("Real content.", section_type="INTRO", ptype="paragraph"),
+            ]
+        )
+        md = bioc_to_markdown(doc)
+        assert "Real content." in md
+        # Should only have the intro heading + content, not empty lines from blank passages
+        assert md.count("Introduction") == 1
+
+    def test_table_footnote(self):
+        doc = _make_document(
+            [
+                _make_passage("p < 0.05", section_type="TABLE", ptype="table_footnote"),
+            ]
+        )
+        md = bioc_to_markdown(doc)
+        assert "*p < 0.05*" in md
+
+    def test_discussion_and_conclusion(self):
+        doc = _make_document(
+            [
+                _make_passage(
+                    "Discussion text.", section_type="DISCUSS", ptype="paragraph"
+                ),
+                _make_passage(
+                    "Conclusion text.", section_type="CONCL", ptype="paragraph"
+                ),
+            ]
+        )
+        md = bioc_to_markdown(doc)
+        assert "## Discussion" in md
+        assert "## Conclusion" in md
+
+
+class TestExtractFigureFiles:
+    def test_no_figures(self):
+        doc = _make_document(
+            [
+                _make_passage("Text.", section_type="INTRO", ptype="paragraph"),
+            ]
+        )
+        assert extract_figure_files(doc) == []
+
+    def test_image_figures(self):
+        doc = _make_document(
+            [
+                _make_passage(
+                    "Caption.",
+                    section_type="FIG",
+                    ptype="fig_caption",
+                    file="fig1.jpg",
+                    id="F1",
+                ),
+                _make_passage(
+                    "Caption.",
+                    section_type="FIG",
+                    ptype="fig_caption",
+                    file="fig2.png",
+                    id="F2",
+                ),
+            ]
+        )
+        figures = extract_figure_files(doc)
+        assert len(figures) == 2
+        assert figures[0] == ("F1", "fig1.jpg")
+        assert figures[1] == ("F2", "fig2.png")
+
+    def test_xml_files_excluded(self):
+        doc = _make_document(
+            [
+                _make_passage(
+                    "Table.",
+                    section_type="TABLE",
+                    ptype="table",
+                    file="T1.xml",
+                    id="T1",
+                ),
+            ]
+        )
+        assert extract_figure_files(doc) == []
+
+    def test_no_duplicates(self):
+        doc = _make_document(
+            [
+                _make_passage(
+                    "Caption.",
+                    section_type="FIG",
+                    ptype="fig_caption",
+                    file="fig1.jpg",
+                    id="F1",
+                ),
+                _make_passage(
+                    "Alt caption.",
+                    section_type="FIG",
+                    ptype="fig_title_caption",
+                    file="fig1.jpg",
+                    id="F1",
+                ),
+            ]
+        )
+        figures = extract_figure_files(doc)
+        assert len(figures) == 1
+
+
+class TestExtractMetadata:
+    def test_extracts_front_matter(self):
+        doc = _make_document(
+            [
+                {
+                    "infons": {
+                        "section_type": "TITLE",
+                        "type": "front",
+                        "article-id_doi": "10.1234/test",
+                        "article-id_pmc": "PMC12345",
+                        "article-id_pmid": "67890",
+                        "year": "2023",
+                        "volume": "10",
+                        "issue": "2",
+                        "license": "CC BY",
+                        "name_0": "surname:Smith;given-names:John",
+                        "name_1": "surname:Doe;given-names:Jane",
+                    },
+                    "text": "Article Title",
+                    "sentences": [],
+                    "annotations": [],
+                    "relations": [],
+                },
+            ]
+        )
+        meta = extract_metadata(doc)
+        assert meta["doi"] == "10.1234/test"
+        assert meta["pmcid"] == "PMC12345"
+        assert meta["pmid"] == "67890"
+        assert meta["year"] == "2023"
+        assert meta["title"] == "Article Title"
+        assert len(meta["authors"]) == 2
+        assert "Smith" in meta["authors"][0]
+
+    def test_no_front_matter(self):
+        doc = _make_document(
+            [
+                _make_passage("Text.", section_type="INTRO", ptype="paragraph"),
+            ]
+        )
+        assert extract_metadata(doc) == {}
+
+
+class TestIsImageFile:
+    def test_jpg(self):
+        assert _is_image_file("fig1.jpg") is True
+
+    def test_png(self):
+        assert _is_image_file("fig1.png") is True
+
+    def test_svg(self):
+        assert _is_image_file("diagram.svg") is True
+
+    def test_xml(self):
+        assert _is_image_file("table.xml") is False
+
+    def test_no_extension(self):
+        assert _is_image_file("noextension") is False
+
+    def test_case_insensitive(self):
+        assert _is_image_file("FIG.JPG") is True
+
+
+class TestFormatTableText:
+    def test_simple_table(self):
+        text = "Name\tAge\nAlice\t30\nBob\t25"
+        result = _format_table_text(text)
+        assert "| Name | Age |" in result
+        assert "| --- | --- |" in result
+        assert "| Alice | 30 |" in result
+        assert "| Bob | 25 |" in result
+
+    def test_single_column(self):
+        text = "Item\nA\nB"
+        result = _format_table_text(text)
+        assert "| Item |" in result
+        assert "| A |" in result
+
+    def test_uneven_columns(self):
+        text = "A\tB\tC\nX\tY"
+        result = _format_table_text(text)
+        # Short row should be padded
+        assert result.count("|") > 0
+
+    def test_empty_string(self):
+        assert _format_table_text("") == ""


### PR DESCRIPTION
## Summary

Closes #19.

- For papers in the PMC Open Access subset (~4M+ articles), opencite can now fetch structured full-text directly from PMC and convert to markdown, bypassing the PDF download + conversion pipeline entirely
- When `--convert` is used with `pdf` or `batch-fetch`, the system tries PMC BioC full text first, then falls back to PDF download + conversion
- Users can opt out with `--no-fulltext` to force the PDF path

## Changes

**New modules:**
- `clients/pmc.py` -- PMC BioC REST API client (`fetch_full_text`, `check_oa_status`, `fetch_image`) and OA Web Service integration
- `pmc_convert.py` -- BioC JSON to markdown converter handling all section types (TITLE, ABSTRACT, INTRO, METHODS, RESULTS, DISCUSS, CONCL, FIG, TABLE, REF), figure image references, and table formatting
- `fulltext.py` -- `FullTextRetriever` orchestrator: resolves PMCID (from paper metadata or ID converter), fetches BioC structured text, converts to markdown, downloads figure images

**Modified modules:**
- `pdf.py` -- Added `retrieve_as_markdown()` method that tries PMC full text before falling back to PDF download + convert
- `batch.py` -- Added `prefer_fulltext` parameter and `fulltext_retrieved` counter to `BatchResult`
- `cli.py` -- Added `--no-fulltext` flag to `pdf` and `batch-fetch` subcommands

## Test plan

- [x] 49 new unit tests across 3 test files (test_pmc_client.py, test_pmc_convert.py, test_fulltext.py)
- [x] All 559 tests pass (including all existing tests)
- [x] Ruff lint and format clean
- [ ] Manual test with known PMC OA article (e.g., PMC5334499)
- [ ] Manual test with non-OA article to verify graceful fallback to PDF