### PR TITLE
Add Unpaywall, CrossRef, and CORE clients; fix silent PDF failures (#21)

### DIFF
--- a/src/opencite/__init__.py
+++ b/src/opencite/__init__.py
@@ -1,6 +1,6 @@
 """opencite: Academic literature search, citation management, and PDF retrieval."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 from .config import Config
 from .models import (

--- a/src/opencite/cli.py
+++ b/src/opencite/cli.py
@@ -30,7 +30,7 @@ def create_parser() -> argparse.ArgumentParser:
     search_p.add_argument("query", help="search query string")
     search_p.add_argument(
         "--source",
-        choices=["openalex", "s2", "pubmed", "all"],
+        choices=["openalex", "s2", "pubmed", "arxiv", "biorxiv", "crossref", "core", "all"],
         default="all",
         help="search source (default: all)",
     )

--- a/src/opencite/cli.py
+++ b/src/opencite/cli.py
@@ -30,7 +30,16 @@ def create_parser() -> argparse.ArgumentParser:
     search_p.add_argument("query", help="search query string")
     search_p.add_argument(
         "--source",
-        choices=["openalex", "s2", "pubmed", "arxiv", "biorxiv", "crossref", "core", "all"],
+        choices=[
+            "openalex",
+            "s2",
+            "pubmed",
+            "arxiv",
+            "biorxiv",
+            "crossref",
+            "core",
+            "all",
+        ],
         default="all",
         help="search source (default: all)",
     )

--- a/src/opencite/clients/core.py
+++ b/src/opencite/clients/core.py
@@ -36,7 +36,7 @@ class COREClient(BaseClient):
         super().__init__(
             config=config,
             base_url=BASE_URL,
-            rate_limit=0.5,  # 5 req per 10 seconds
+            rate_limit=config.core_rate_limit,
             burst=2,
         )
 

--- a/src/opencite/clients/core.py
+++ b/src/opencite/clients/core.py
@@ -10,6 +10,7 @@ The free tier allows 1 batch request or 5 single requests per 10 seconds.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -63,11 +64,11 @@ class COREClient(BaseClient):
 
         try:
             resp = await self.get("/v3/search/works", params=params)
+            data = resp.json()
         except Exception as e:
             logger.warning("CORE search failed: %s", e)
             return []
 
-        data = resp.json()
         results = data.get("results", [])
         return [p for item in results if (p := _parse_work(item)) is not None]
 
@@ -80,11 +81,11 @@ class COREClient(BaseClient):
             resp = await self.get(
                 "/v3/search/works", params={"q": f'doi:"{doi}"', "limit": 1}
             )
+            data = resp.json()
         except Exception as e:
             logger.debug("CORE lookup failed for %s: %s", doi, e)
             return None
 
-        data = resp.json()
         results = data.get("results", [])
         if not results:
             return None
@@ -105,6 +106,12 @@ def _parse_work(work: dict[str, Any]) -> Paper | None:
         doi = doi[len("http://doi.org/") :]
 
     year = work.get("yearPublished")
+
+    # Publication date
+    pub_date = work.get("publishedDate") or work.get("depositedDate") or ""
+    if pub_date and not year:
+        with contextlib.suppress(ValueError, IndexError):
+            year = int(pub_date[:4])
 
     # Authors
     authors = []
@@ -152,6 +159,7 @@ def _parse_work(work: dict[str, Any]) -> Paper | None:
         authors=authors,
         year=year,
         source_venue=source_venue,
+        publication_date=pub_date,
         abstract=abstract,
         pdf_locations=pdf_locations,
         is_oa=True,

--- a/src/opencite/clients/core.py
+++ b/src/opencite/clients/core.py
@@ -1,0 +1,159 @@
+"""CORE API client.
+
+CORE (https://core.ac.uk) aggregates open access research from thousands
+of repositories and journals worldwide -- the world's largest collection
+of OA full texts (300M+ metadata records, 40M+ full texts).
+
+Requires a free API key from https://core.ac.uk/services/api.
+The free tier allows 1 batch request or 5 single requests per 10 seconds.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from opencite.clients.base import BaseClient
+from opencite.models import Author, IDSet, Paper, PDFLocation, Source
+
+if TYPE_CHECKING:
+    from opencite.config import Config
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://api.core.ac.uk"
+
+
+class COREClient(BaseClient):
+    """Client for the CORE API v3.
+
+    Provides keyword search and DOI lookup for open access papers,
+    including full-text download URLs.
+    """
+
+    def __init__(self, config: Config):
+        super().__init__(
+            config=config,
+            base_url=BASE_URL,
+            rate_limit=0.5,  # 5 req per 10 seconds
+            burst=2,
+        )
+
+    def _default_headers(self) -> dict[str, str]:
+        headers: dict[str, str] = {"Accept": "application/json"}
+        api_key = self.config.core_api_key
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        return headers
+
+    @property
+    def _enabled(self) -> bool:
+        return bool(self.config.core_api_key)
+
+    async def search(self, query: str, max_results: int = 20) -> list[Paper]:
+        """Search CORE for open access papers."""
+        if not self._enabled:
+            logger.debug("CORE API key not set; skipping search")
+            return []
+
+        params: dict[str, Any] = {
+            "q": query,
+            "limit": min(max_results, 100),
+        }
+
+        try:
+            resp = await self.get("/v3/search/works", params=params)
+        except Exception as e:
+            logger.warning("CORE search failed: %s", e)
+            return []
+
+        data = resp.json()
+        results = data.get("results", [])
+        return [p for item in results if (p := _parse_work(item)) is not None]
+
+    async def lookup_doi(self, doi: str) -> Paper | None:
+        """Look up a paper by DOI in CORE."""
+        if not self._enabled:
+            return None
+
+        try:
+            resp = await self.get(
+                "/v3/search/works", params={"q": f'doi:"{doi}"', "limit": 1}
+            )
+        except Exception as e:
+            logger.debug("CORE lookup failed for %s: %s", doi, e)
+            return None
+
+        data = resp.json()
+        results = data.get("results", [])
+        if not results:
+            return None
+        return _parse_work(results[0])
+
+
+def _parse_work(work: dict[str, Any]) -> Paper | None:
+    """Parse a CORE work/output into a Paper."""
+    title = work.get("title", "")
+    if not title:
+        return None
+
+    doi = work.get("doi") or ""
+    # CORE sometimes prefixes DOIs with https://doi.org/
+    if doi.startswith("https://doi.org/"):
+        doi = doi[len("https://doi.org/") :]
+    elif doi.startswith("http://doi.org/"):
+        doi = doi[len("http://doi.org/") :]
+
+    year = work.get("yearPublished")
+
+    # Authors
+    authors = []
+    for auth_name in work.get("authors", [])[:50]:
+        if isinstance(auth_name, str) and auth_name:
+            authors.append(Author(name=auth_name))
+        elif isinstance(auth_name, dict):
+            name = auth_name.get("name", "")
+            if name:
+                authors.append(Author(name=name))
+
+    # Venue
+    journal = work.get("journals", [])
+    venue_name = ""
+    if journal and isinstance(journal[0], dict):
+        venue_name = journal[0].get("title", "")
+    elif journal and isinstance(journal[0], str):
+        venue_name = journal[0]
+
+    source_venue = Source(name=venue_name) if venue_name else None
+
+    # Abstract
+    abstract = (work.get("abstract") or "")[:1000]
+
+    # PDF / full-text URLs
+    pdf_locations = []
+    download_url = work.get("downloadUrl") or ""
+    if download_url:
+        pdf_locations.append(
+            PDFLocation(
+                url=download_url,
+                source="core",
+                is_oa=True,
+            )
+        )
+
+    # Also check sourceFulltextUrls
+    for url in work.get("sourceFulltextUrls", []) or []:
+        if url and url not in {loc.url for loc in pdf_locations}:
+            pdf_locations.append(PDFLocation(url=url, source="core", is_oa=True))
+
+    return Paper(
+        title=title,
+        ids=IDSet(doi=doi),
+        authors=authors,
+        year=year,
+        source_venue=source_venue,
+        abstract=abstract,
+        pdf_locations=pdf_locations,
+        is_oa=True,
+        data_sources={"core"},
+    )

--- a/src/opencite/clients/crossref.py
+++ b/src/opencite/clients/crossref.py
@@ -39,7 +39,7 @@ class CrossRefClient(BaseClient):
         super().__init__(
             config=config,
             base_url=BASE_URL,
-            rate_limit=50.0,  # polite pool allows ~50/sec
+            rate_limit=config.crossref_rate_limit,
             burst=10,
         )
 

--- a/src/opencite/clients/crossref.py
+++ b/src/opencite/clients/crossref.py
@@ -12,7 +12,9 @@ This client provides:
 
 from __future__ import annotations
 
+import contextlib
 import logging
+import re
 from typing import TYPE_CHECKING, Any
 
 from opencite.clients.base import BaseClient
@@ -75,11 +77,11 @@ class CrossRefClient(BaseClient):
 
         try:
             resp = await self.get("/works", params=params)
+            data = resp.json()
         except Exception as e:
             logger.warning("CrossRef search failed: %s", e)
             return []
 
-        data = resp.json()
         items = data.get("message", {}).get("items", [])
         return [p for item in items if (p := _parse_work(item)) is not None]
 
@@ -87,11 +89,11 @@ class CrossRefClient(BaseClient):
         """Look up a single work by DOI."""
         try:
             resp = await self.get(f"/works/{doi}")
+            data = resp.json()
         except Exception as e:
             logger.debug("CrossRef lookup failed for %s: %s", doi, e)
             return None
 
-        data = resp.json()
         work = data.get("message", {})
         return _parse_work(work)
 
@@ -110,7 +112,8 @@ def _parse_work(work: dict[str, Any]) -> Paper | None:
     for date_field in ("published-print", "published-online"):
         parts = work.get(date_field, {}).get("date-parts", [[]])
         if parts and parts[0] and parts[0][0]:
-            year = parts[0][0]
+            with contextlib.suppress(TypeError, ValueError):
+                year = int(parts[0][0])
             break
 
     # Publication date string
@@ -154,8 +157,6 @@ def _parse_work(work: dict[str, Any]) -> Paper | None:
     # Abstract (CrossRef provides JATS XML; strip tags)
     abstract = work.get("abstract", "")
     if abstract:
-        import re
-
         abstract = re.sub(r"<[^>]+>", "", abstract).strip()[:1000]
 
     # PDF locations from link records

--- a/src/opencite/clients/crossref.py
+++ b/src/opencite/clients/crossref.py
@@ -1,0 +1,190 @@
+"""CrossRef REST API client.
+
+CrossRef (https://api.crossref.org) is the authoritative DOI metadata
+registry with 150M+ works.  No API key required; providing a contact
+email activates the "polite" pool with better throughput.
+
+This client provides:
+- DOI metadata lookup (filling gaps when S2/OpenAlex miss a DOI)
+- Keyword search across all registered works
+- PDF link extraction from CrossRef ``link`` records
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from opencite.clients.base import BaseClient
+from opencite.models import Author, IDSet, Paper, PDFLocation, Source
+
+if TYPE_CHECKING:
+    from opencite.config import Config
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://api.crossref.org"
+
+
+class CrossRefClient(BaseClient):
+    """Client for the CrossRef REST API.
+
+    Provides broad DOI-based metadata coverage and keyword search
+    for works not indexed by the existing five sources.
+    """
+
+    def __init__(self, config: Config):
+        super().__init__(
+            config=config,
+            base_url=BASE_URL,
+            rate_limit=50.0,  # polite pool allows ~50/sec
+            burst=10,
+        )
+
+    def _default_headers(self) -> dict[str, str]:
+        headers: dict[str, str] = {"Accept": "application/json"}
+        if self.config.contact_email:
+            headers["User-Agent"] = f"opencite/0.1 (mailto:{self.config.contact_email})"
+        return headers
+
+    async def search(
+        self,
+        query: str,
+        max_results: int = 20,
+        year_from: int | None = None,
+        year_to: int | None = None,
+    ) -> list[Paper]:
+        """Search CrossRef works by keyword query."""
+        params: dict[str, Any] = {
+            "query": query,
+            "rows": min(max_results, 100),
+            "select": (
+                "DOI,title,author,published-print,published-online,"
+                "container-title,type,abstract,is-referenced-by-count,"
+                "link,ISSN,publisher"
+            ),
+        }
+
+        filters: list[str] = []
+        if year_from:
+            filters.append(f"from-pub-date:{year_from}")
+        if year_to:
+            filters.append(f"until-pub-date:{year_to}")
+        if filters:
+            params["filter"] = ",".join(filters)
+
+        try:
+            resp = await self.get("/works", params=params)
+        except Exception as e:
+            logger.warning("CrossRef search failed: %s", e)
+            return []
+
+        data = resp.json()
+        items = data.get("message", {}).get("items", [])
+        return [p for item in items if (p := _parse_work(item)) is not None]
+
+    async def lookup_doi(self, doi: str) -> Paper | None:
+        """Look up a single work by DOI."""
+        try:
+            resp = await self.get(f"/works/{doi}")
+        except Exception as e:
+            logger.debug("CrossRef lookup failed for %s: %s", doi, e)
+            return None
+
+        data = resp.json()
+        work = data.get("message", {})
+        return _parse_work(work)
+
+
+def _parse_work(work: dict[str, Any]) -> Paper | None:
+    """Parse a CrossRef work item into a Paper."""
+    title_list = work.get("title", [])
+    if not title_list:
+        return None
+    title = title_list[0]
+
+    doi = work.get("DOI", "")
+
+    # Extract year from published-print or published-online
+    year = None
+    for date_field in ("published-print", "published-online"):
+        parts = work.get(date_field, {}).get("date-parts", [[]])
+        if parts and parts[0] and parts[0][0]:
+            year = parts[0][0]
+            break
+
+    # Publication date string
+    pub_date = ""
+    for date_field in ("published-print", "published-online"):
+        parts = work.get(date_field, {}).get("date-parts", [[]])
+        if parts and parts[0]:
+            pub_date = "-".join(str(p) for p in parts[0] if p)
+            break
+
+    # Authors
+    authors = []
+    for auth in work.get("author", [])[:50]:
+        family = auth.get("family", "")
+        given = auth.get("given", "")
+        name = f"{given} {family}".strip() if given and family else family or given
+        if name:
+            authors.append(
+                Author(
+                    name=name,
+                    family_name=family,
+                    given_name=given,
+                    orcid=auth.get("ORCID", "") or "",
+                )
+            )
+
+    # Source/venue
+    container = work.get("container-title", [])
+    venue_name = container[0] if container else ""
+    issn_list = work.get("ISSN", [])
+    source_venue = (
+        Source(
+            name=venue_name,
+            issn=issn_list[0] if issn_list else "",
+            publisher=work.get("publisher", ""),
+        )
+        if venue_name
+        else None
+    )
+
+    # Abstract (CrossRef provides JATS XML; strip tags)
+    abstract = work.get("abstract", "")
+    if abstract:
+        import re
+
+        abstract = re.sub(r"<[^>]+>", "", abstract).strip()[:1000]
+
+    # PDF locations from link records
+    pdf_locations = []
+    for link in work.get("link", []):
+        if link.get("content-type") == "application/pdf":
+            url = link.get("URL", "")
+            if url:
+                pdf_locations.append(
+                    PDFLocation(
+                        url=url,
+                        source="crossref",
+                        version="publishedVersion",
+                        is_oa=False,
+                    )
+                )
+
+    citation_count = work.get("is-referenced-by-count", 0) or 0
+
+    return Paper(
+        title=title,
+        ids=IDSet(doi=doi),
+        authors=authors,
+        year=year,
+        source_venue=source_venue,
+        publication_date=pub_date,
+        pub_type=work.get("type", ""),
+        abstract=abstract,
+        citation_count=citation_count,
+        pdf_locations=pdf_locations,
+        data_sources={"crossref"},
+    )

--- a/src/opencite/clients/unpaywall.py
+++ b/src/opencite/clients/unpaywall.py
@@ -1,0 +1,102 @@
+"""Unpaywall API client.
+
+Unpaywall (https://unpaywall.org) provides open access PDF locations for
+papers identified by DOI.  It indexes OA copies from 50,000+ publishers
+and repositories.
+
+Requires a contact email (``config.contact_email``) -- no API key needed.
+Free tier allows up to 100,000 calls per day.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from opencite.clients.base import BaseClient
+from opencite.models import PDFLocation
+
+if TYPE_CHECKING:
+    from opencite.config import Config
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://api.unpaywall.org"
+
+
+class UnpaywallClient(BaseClient):
+    """Client for the Unpaywall REST API.
+
+    Looks up open access PDF locations by DOI.  This is the single most
+    effective source for finding free PDFs of paywalled papers.
+    """
+
+    def __init__(self, config: Config):
+        super().__init__(
+            config=config,
+            base_url=BASE_URL,
+            rate_limit=10.0,  # conservative; daily cap is 100k
+            burst=5,
+        )
+
+    def _default_headers(self) -> dict[str, str]:
+        return {"Accept": "application/json"}
+
+    async def lookup_doi(self, doi: str) -> list[PDFLocation]:
+        """Find open access PDF locations for a DOI.
+
+        Returns a list of PDFLocation objects sorted by quality
+        (best OA location first).
+        """
+        email = self.config.contact_email
+        if not email:
+            logger.debug("Unpaywall requires contact_email; skipping lookup")
+            return []
+
+        try:
+            resp = await self.get(f"/v2/{doi}", params={"email": email})
+        except Exception as e:
+            logger.debug("Unpaywall lookup failed for %s: %s", doi, e)
+            return []
+
+        data = resp.json()
+        return _extract_locations(data)
+
+
+def _extract_locations(data: dict[str, Any]) -> list[PDFLocation]:
+    """Extract PDF locations from an Unpaywall API response."""
+    locations: list[PDFLocation] = []
+    seen_urls: set[str] = set()
+
+    # Best OA location first
+    best = data.get("best_oa_location")
+    if best:
+        loc = _parse_location(best)
+        if loc and loc.url not in seen_urls:
+            locations.append(loc)
+            seen_urls.add(loc.url)
+
+    # Then all other OA locations
+    for oa_loc in data.get("oa_locations", []):
+        loc = _parse_location(oa_loc)
+        if loc and loc.url not in seen_urls:
+            locations.append(loc)
+            seen_urls.add(loc.url)
+
+    return locations
+
+
+def _parse_location(loc: dict[str, Any]) -> PDFLocation | None:
+    """Parse a single Unpaywall OA location into a PDFLocation."""
+    # Prefer url_for_pdf, fall back to url_for_landing_page
+    url = loc.get("url_for_pdf") or ""
+    if not url:
+        return None
+
+    return PDFLocation(
+        url=url,
+        source="unpaywall",
+        version=loc.get("version", ""),
+        is_oa=True,
+        license=loc.get("license") or "",
+    )

--- a/src/opencite/clients/unpaywall.py
+++ b/src/opencite/clients/unpaywall.py
@@ -55,11 +55,11 @@ class UnpaywallClient(BaseClient):
 
         try:
             resp = await self.get(f"/v2/{doi}", params={"email": email})
+            data = resp.json()
         except Exception as e:
             logger.debug("Unpaywall lookup failed for %s: %s", doi, e)
             return []
 
-        data = resp.json()
         return _extract_locations(data)
 
 

--- a/src/opencite/clients/unpaywall.py
+++ b/src/opencite/clients/unpaywall.py
@@ -35,7 +35,7 @@ class UnpaywallClient(BaseClient):
         super().__init__(
             config=config,
             base_url=BASE_URL,
-            rate_limit=10.0,  # conservative; daily cap is 100k
+            rate_limit=config.unpaywall_rate_limit,
             burst=5,
         )
 
@@ -88,8 +88,9 @@ def _extract_locations(data: dict[str, Any]) -> list[PDFLocation]:
 
 def _parse_location(loc: dict[str, Any]) -> PDFLocation | None:
     """Parse a single Unpaywall OA location into a PDFLocation."""
-    # Prefer url_for_pdf, fall back to url_for_landing_page
-    url = loc.get("url_for_pdf") or ""
+    # Prefer url_for_pdf, fall back to url_for_landing_page (which may
+    # redirect to a PDF or at least provide OA access)
+    url = loc.get("url_for_pdf") or loc.get("url_for_landing_page") or ""
     if not url:
         return None
 

--- a/src/opencite/config.py
+++ b/src/opencite/config.py
@@ -31,6 +31,7 @@ semantic_scholar = ""
 pubmed = ""
 openalex = ""
 mistral = ""
+# core = ""  # CORE API key (free at https://core.ac.uk/services/api)
 
 [publishers]
 # elsevier = ""
@@ -58,6 +59,7 @@ _TOML_MAP: dict[tuple[str, str], tuple[str, str]] = {
     ("api_keys", "pubmed"): ("pubmed_api_key", "PUBMED_API_KEY"),
     ("api_keys", "openalex"): ("openalex_api_key", "OPENALEX_API_KEY"),
     ("api_keys", "mistral"): ("mistral_api_key", "MISTRAL_API_KEY"),
+    ("api_keys", "core"): ("core_api_key", "CORE_API_KEY"),
     ("publishers", "elsevier"): ("elsevier_api_key", "OPENCITE_ELSEVIER_KEY"),
     ("publishers", "wiley_tdm"): ("wiley_tdm_token", "OPENCITE_WILEY_TDM_TOKEN"),
     ("publishers", "springer"): ("springer_api_key", "OPENCITE_SPRINGER_KEY"),
@@ -157,6 +159,9 @@ class Config:
     openalex_api_key: str = ""
     mistral_api_key: str = ""
 
+    # Additional source keys
+    core_api_key: str = ""
+
     # Publisher tokens
     elsevier_api_key: str = ""
     wiley_tdm_token: str = ""
@@ -168,6 +173,9 @@ class Config:
     pubmed_rate_limit: float = 10.0
     arxiv_rate_limit: float = 3.0
     biorxiv_rate_limit: float = 10.0
+    crossref_rate_limit: float = 50.0
+    core_rate_limit: float = 0.5
+    unpaywall_rate_limit: float = 10.0
 
     # Request settings
     timeout: float = 30.0

--- a/src/opencite/pdf.py
+++ b/src/opencite/pdf.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 import httpx
 
 from opencite.clients.id_converter import IDConverterClient
+from opencite.clients.unpaywall import UnpaywallClient
 from opencite.models import IDType, Paper, parse_identifier
 
 if TYPE_CHECKING:
@@ -42,6 +43,38 @@ _PUBLISHER_MAP: dict[str, tuple[str, str, str]] = {
     ),
 }
 
+# Known DOI prefixes and their publishers -- used for informational hints
+# when PDF retrieval fails, to guide users toward the right access method.
+# Sources: CrossRef prefix registry.
+PUBLISHER_INFO: dict[str, str] = {
+    # Publishers with authenticated API access (see _PUBLISHER_MAP above)
+    "10.1016": "Elsevier/ScienceDirect (set elsevier_api_key for TDM access)",
+    "10.1002": "Wiley (set wiley_tdm_token for TDM access)",
+    "10.1007": "Springer (set springer_api_key for OA access)",
+    "10.1038": "Springer Nature (set springer_api_key for OA access)",
+    # Major publishers without direct API -- rely on Unpaywall, OA repos, or DOI
+    "10.1109": "IEEE (PDFs often via Unpaywall or institutional access)",
+    "10.1145": "ACM (PDFs often via Unpaywall or ACM Open TOC)",
+    "10.1126": "Science/AAAS (PDFs via Unpaywall or institutional access)",
+    "10.1093": "Oxford University Press (check Unpaywall for OA copies)",
+    "10.1080": "Taylor & Francis (check Unpaywall for OA copies)",
+    "10.1177": "SAGE Publications (check Unpaywall for OA copies)",
+    "10.1371": "PLOS (open access -- should always have free PDF)",
+    "10.3389": "Frontiers (open access -- should always have free PDF)",
+    "10.7554": "eLife (open access -- should always have free PDF)",
+    "10.1523": "J. Neuroscience (check Unpaywall, many are OA after embargo)",
+    "10.1101": "bioRxiv/medRxiv (always open access)",
+    "10.48550": "arXiv (always open access)",
+    "10.1136": "BMJ (check Unpaywall for OA copies)",
+    "10.1001": "JAMA Network (check Unpaywall for OA copies)",
+    "10.1056": "NEJM (check Unpaywall for OA copies)",
+    "10.1161": "AHA Journals (check Unpaywall for OA copies)",
+    "10.1073": "PNAS (OA after 6 months, check Unpaywall)",
+    "10.1172": "JCI (open access)",
+    "10.1242": "Company of Biologists (check Unpaywall for OA copies)",
+    "10.1113": "J. Physiology (check Unpaywall for OA copies)",
+}
+
 
 class PDFRetriever:
     """Download PDFs for academic papers.
@@ -60,13 +93,16 @@ class PDFRetriever:
     def __init__(self, config: Config):
         self.config = config
         self._id_converter = IDConverterClient(config)
+        self._unpaywall = UnpaywallClient(config)
 
     async def __aenter__(self) -> PDFRetriever:
         await self._id_converter.__aenter__()
+        await self._unpaywall.__aenter__()
         return self
 
     async def __aexit__(self, *args: object) -> None:
         await self._id_converter.__aexit__()
+        await self._unpaywall.__aexit__()
 
     async def download(
         self,
@@ -105,7 +141,7 @@ class PDFRetriever:
         if paper is None:
             paper = await self._quick_lookup(identifier)
 
-        urls = self._collect_urls(paper, identifier)
+        urls = await self._collect_urls(paper, identifier)
 
         if not urls:
             logger.warning("No PDF URLs found for %s", identifier)
@@ -130,7 +166,7 @@ class PDFRetriever:
         async with SearchOrchestrator(self.config) as searcher:
             return await searcher.lookup(identifier, enrich=False)
 
-    def _collect_urls(self, paper: Paper | None, identifier: str) -> list[str]:
+    async def _collect_urls(self, paper: Paper | None, identifier: str) -> list[str]:
         """Collect candidate PDF URLs in priority order."""
         urls: list[str] = []
 
@@ -167,7 +203,17 @@ class PDFRetriever:
                 if pmc_url not in urls:
                     urls.append(pmc_url)
 
-        # Priority 4a: Direct bioRxiv/medRxiv PDF for 10.1101/ DOIs
+        # Priority 4: Unpaywall -- finds OA copies across 50k+ repositories
+        if doi:
+            try:
+                unpaywall_locs = await self._unpaywall.lookup_doi(doi)
+                for loc in unpaywall_locs:
+                    if loc.url and loc.url not in urls:
+                        urls.append(loc.url)
+            except Exception as e:
+                logger.debug("Unpaywall lookup failed for %s: %s", doi, e)
+
+        # Priority 5a: Direct bioRxiv/medRxiv PDF for 10.1101/ DOIs
         if doi and doi.startswith("10.1101/"):
             preprint_server = "biorxiv"
             if paper and (
@@ -179,7 +225,7 @@ class PDFRetriever:
             if preprint_pdf not in urls:
                 urls.append(preprint_pdf)
 
-        # Priority 4b: DOI content negotiation
+        # Priority 5b: DOI content negotiation
         if doi:
             doi_url = f"https://doi.org/{doi}"
             if doi_url not in urls:
@@ -267,7 +313,13 @@ class PDFRetriever:
         failures: list[tuple[str, str]],
         paper: Paper | None,
     ) -> None:
-        """Report detailed failure summary."""
+        """Report detailed failure summary.
+
+        Uses print() to stderr for user-visible messages so failures
+        are always reported regardless of log level (fixes #21).
+        """
+        import sys
+
         if not failures:
             logger.warning("All PDF download attempts failed for %s", identifier)
             return
@@ -279,14 +331,13 @@ class PDFRetriever:
             summary_parts.append(f"  {short}: {reason}")
 
         summary = "\n".join(summary_parts)
-        logger.warning(
-            "PDF download failed for %s. Tried %d source(s):\n%s",
-            identifier,
-            len(failures),
-            summary,
+        print(
+            f"PDF download failed for {identifier}. "
+            f"Tried {len(failures)} source(s):\n{summary}",
+            file=sys.stderr,
         )
 
-        # Suggest institutional access
+        # Suggest institutional access and Unpaywall
         doi = paper.doi if paper else None
         if not doi:
             try:
@@ -297,10 +348,28 @@ class PDFRetriever:
                 pass
 
         if doi:
-            logger.info(
-                "Paper may be available via institutional access: https://doi.org/%s",
-                doi,
-            )
+            hints = [f"  Institutional access: https://doi.org/{doi}"]
+            if not self.config.contact_email:
+                hints.append(
+                    "  Tip: Set contact_email in config to enable Unpaywall "
+                    "(finds OA copies from 50k+ repositories)"
+                )
+            # Check for unconfigured publisher tokens
+            prefix = doi.split("/")[0] if "/" in doi else ""
+            pub_info = _PUBLISHER_MAP.get(prefix)
+            if pub_info:
+                name, _url, config_key = pub_info
+                if not getattr(self.config, config_key, ""):
+                    hints.append(
+                        f"  Tip: Set {config_key} in config for authenticated "
+                        f"{name} downloads"
+                    )
+            # Show publisher-specific guidance
+            publisher_hint = PUBLISHER_INFO.get(prefix)
+            if publisher_hint:
+                hints.append(f"  Publisher: {publisher_hint}")
+            if hints:
+                print("\n".join(hints), file=sys.stderr)
 
     async def retrieve_as_markdown(
         self,

--- a/src/opencite/pdf.py
+++ b/src/opencite/pdf.py
@@ -321,7 +321,10 @@ class PDFRetriever:
         import sys
 
         if not failures:
-            logger.warning("All PDF download attempts failed for %s", identifier)
+            print(
+                f"PDF download failed for {identifier}: no sources attempted.",
+                file=sys.stderr,
+            )
             return
 
         summary_parts = []

--- a/src/opencite/search.py
+++ b/src/opencite/search.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING
 
 from opencite.clients.arxiv import ArXivClient
 from opencite.clients.biorxiv import BioRxivClient
+from opencite.clients.core import COREClient
+from opencite.clients.crossref import CrossRefClient
 from opencite.clients.openalex import OpenAlexClient
 from opencite.clients.pubmed import PubMedClient
 from opencite.clients.semantic_scholar import SemanticScholarClient
@@ -19,7 +21,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-ALL_SOURCES = ("openalex", "s2", "pubmed", "arxiv", "biorxiv")
+ALL_SOURCES = ("openalex", "s2", "pubmed", "arxiv", "biorxiv", "crossref", "core")
 
 
 class SearchOrchestrator:
@@ -40,6 +42,8 @@ class SearchOrchestrator:
         self._pubmed = PubMedClient(config)
         self._arxiv = ArXivClient(config)
         self._biorxiv = BioRxivClient(config)
+        self._crossref = CrossRefClient(config)
+        self._core = COREClient(config)
 
     async def __aenter__(self) -> SearchOrchestrator:
         await self._openalex.__aenter__()
@@ -47,6 +51,8 @@ class SearchOrchestrator:
         await self._pubmed.__aenter__()
         await self._arxiv.__aenter__()
         await self._biorxiv.__aenter__()
+        await self._crossref.__aenter__()
+        await self._core.__aenter__()
         return self
 
     async def __aexit__(self, *args: object) -> None:
@@ -55,6 +61,8 @@ class SearchOrchestrator:
         await self._pubmed.__aexit__()
         await self._arxiv.__aexit__()
         await self._biorxiv.__aexit__()
+        await self._crossref.__aexit__()
+        await self._core.__aexit__()
 
     async def search(
         self,
@@ -95,6 +103,12 @@ class SearchOrchestrator:
             tasks["biorxiv"] = asyncio.create_task(
                 self._search_biorxiv(query, max_results)
             )
+        if "crossref" in sources:
+            tasks["crossref"] = asyncio.create_task(
+                self._search_crossref(query, max_results, year_from, year_to)
+            )
+        if "core" in sources:
+            tasks["core"] = asyncio.create_task(self._search_core(query, max_results))
 
         all_papers: list[Paper] = []
         source_counts: dict[str, int] = {}
@@ -200,13 +214,29 @@ class SearchOrchestrator:
     async def _search_biorxiv(self, query: str, max_results: int) -> list[Paper]:
         return await self._biorxiv.search(query, max_results=max_results)
 
+    async def _search_crossref(
+        self,
+        query: str,
+        max_results: int,
+        year_from: int | None,
+        year_to: int | None,
+    ) -> list[Paper]:
+        return await self._crossref.search(
+            query, max_results=max_results, year_from=year_from, year_to=year_to
+        )
+
+    async def _search_core(self, query: str, max_results: int) -> list[Paper]:
+        return await self._core.search(query, max_results=max_results)
+
     async def _lookup_by_type(self, id_type: IDType, id_value: str) -> Paper | None:
         """Look up paper using the most appropriate API for the ID type."""
         if id_type == IDType.DOI:
-            # Try S2 first (fast), fall back to OpenAlex
+            # Try S2 first (fast), fall back to OpenAlex, then CrossRef
             paper = await self._s2.lookup(f"DOI:{id_value}")
             if not paper:
                 paper = await self._openalex.lookup_doi(id_value)
+            if not paper:
+                paper = await self._crossref.lookup_doi(id_value)
             return paper
 
         if id_type == IDType.PMID:

--- a/tests/test_clients/test_core.py
+++ b/tests/test_clients/test_core.py
@@ -1,0 +1,100 @@
+"""Tests for the CORE API client."""
+
+from __future__ import annotations
+
+from opencite.clients.core import _parse_work
+
+# -- Unit tests for _parse_work (no API needed) --
+
+SAMPLE_WORK = {
+    "title": "A Survey of Brain-Computer Interfaces",
+    "doi": "https://doi.org/10.1234/test.2024.001",
+    "yearPublished": 2024,
+    "authors": [
+        {"name": "Jane Smith"},
+        {"name": "John Doe"},
+    ],
+    "abstract": "This paper surveys brain-computer interface technologies.",
+    "journals": [{"title": "Journal of Neural Engineering"}],
+    "downloadUrl": "https://core.ac.uk/download/pdf/12345.pdf",
+    "sourceFulltextUrls": [
+        "https://repository.example.edu/papers/12345.pdf",
+    ],
+}
+
+
+def test_parse_work_basic_fields():
+    paper = _parse_work(SAMPLE_WORK)
+    assert paper is not None
+    assert paper.title == "A Survey of Brain-Computer Interfaces"
+    assert paper.doi == "10.1234/test.2024.001"
+    assert paper.year == 2024
+    assert paper.is_oa is True
+    assert "core" in paper.data_sources
+
+
+def test_parse_work_doi_prefix_stripped():
+    """DOI should have https://doi.org/ prefix stripped."""
+    paper = _parse_work(SAMPLE_WORK)
+    assert paper is not None
+    assert not paper.doi.startswith("https://")
+
+
+def test_parse_work_authors():
+    paper = _parse_work(SAMPLE_WORK)
+    assert paper is not None
+    assert len(paper.authors) == 2
+    assert paper.authors[0].name == "Jane Smith"
+
+
+def test_parse_work_string_authors():
+    """CORE sometimes returns authors as plain strings."""
+    work = {
+        "title": "Test",
+        "authors": ["Alice Bob", "Carol Dave"],
+    }
+    paper = _parse_work(work)
+    assert paper is not None
+    assert len(paper.authors) == 2
+    assert paper.authors[0].name == "Alice Bob"
+
+
+def test_parse_work_pdf_locations():
+    paper = _parse_work(SAMPLE_WORK)
+    assert paper is not None
+    assert len(paper.pdf_locations) == 2
+    assert paper.pdf_locations[0].url == "https://core.ac.uk/download/pdf/12345.pdf"
+    assert paper.pdf_locations[0].source == "core"
+    assert paper.pdf_locations[0].is_oa is True
+    assert (
+        paper.pdf_locations[1].url == "https://repository.example.edu/papers/12345.pdf"
+    )
+
+
+def test_parse_work_venue():
+    paper = _parse_work(SAMPLE_WORK)
+    assert paper is not None
+    assert paper.source_venue is not None
+    assert paper.source_venue.name == "Journal of Neural Engineering"
+
+
+def test_parse_work_no_title():
+    assert _parse_work({}) is None
+    assert _parse_work({"title": ""}) is None
+
+
+def test_parse_work_minimal():
+    paper = _parse_work({"title": "Minimal Paper"})
+    assert paper is not None
+    assert paper.doi == ""
+    assert paper.year is None
+    assert paper.authors == []
+    assert paper.pdf_locations == []
+
+
+def test_parse_work_http_doi_prefix():
+    """http://doi.org/ prefix should also be stripped."""
+    work = {"title": "Test", "doi": "http://doi.org/10.1234/test"}
+    paper = _parse_work(work)
+    assert paper is not None
+    assert paper.doi == "10.1234/test"

--- a/tests/test_clients/test_crossref.py
+++ b/tests/test_clients/test_crossref.py
@@ -1,0 +1,102 @@
+"""Tests for the CrossRef API client."""
+
+from __future__ import annotations
+
+from opencite.clients.crossref import _parse_work
+
+# -- Unit tests for _parse_work (no API needed) --
+
+SAMPLE_WORK = {
+    "DOI": "10.1109/tnsre.2010.2041593",
+    "title": ["Brain-Computer Interface-Based Robotic End Effector System"],
+    "author": [
+        {
+            "given": "Keng Peng",
+            "family": "Tee",
+            "ORCID": "https://orcid.org/0000-0001-1234",
+        },
+        {"given": "Shuzhi Sam", "family": "Ge"},
+    ],
+    "published-print": {"date-parts": [[2010, 6]]},
+    "container-title": [
+        "IEEE Transactions on Neural Systems and Rehabilitation Engineering"
+    ],
+    "ISSN": ["1534-4320"],
+    "publisher": "IEEE",
+    "type": "journal-article",
+    "abstract": "<jats:p>This paper presents a brain-computer interface system.</jats:p>",
+    "is-referenced-by-count": 42,
+    "link": [
+        {
+            "URL": "https://ieeexplore.ieee.org/stampPDF/getPDF.jsp?tp=&arnumber=5395649",
+            "content-type": "application/pdf",
+        },
+        {
+            "URL": "https://ieeexplore.ieee.org/document/5395649",
+            "content-type": "text/html",
+        },
+    ],
+}
+
+
+def test_parse_work_basic_fields():
+    paper = _parse_work(SAMPLE_WORK)
+    assert paper is not None
+    assert paper.title == "Brain-Computer Interface-Based Robotic End Effector System"
+    assert paper.doi == "10.1109/tnsre.2010.2041593"
+    assert paper.year == 2010
+    assert paper.citation_count == 42
+    assert "crossref" in paper.data_sources
+
+
+def test_parse_work_authors():
+    paper = _parse_work(SAMPLE_WORK)
+    assert paper is not None
+    assert len(paper.authors) == 2
+    assert paper.authors[0].family_name == "Tee"
+    assert paper.authors[0].given_name == "Keng Peng"
+    assert paper.authors[0].orcid == "https://orcid.org/0000-0001-1234"
+
+
+def test_parse_work_venue():
+    paper = _parse_work(SAMPLE_WORK)
+    assert paper is not None
+    assert paper.source_venue is not None
+    assert "IEEE" in paper.source_venue.name
+    assert paper.source_venue.publisher == "IEEE"
+    assert paper.source_venue.issn == "1534-4320"
+
+
+def test_parse_work_abstract_strips_jats():
+    paper = _parse_work(SAMPLE_WORK)
+    assert paper is not None
+    assert "<jats" not in paper.abstract
+    assert "brain-computer interface" in paper.abstract.lower()
+
+
+def test_parse_work_pdf_links():
+    paper = _parse_work(SAMPLE_WORK)
+    assert paper is not None
+    assert len(paper.pdf_locations) == 1  # only application/pdf
+    assert "stampPDF" in paper.pdf_locations[0].url
+    assert paper.pdf_locations[0].source == "crossref"
+
+
+def test_parse_work_no_title():
+    assert _parse_work({}) is None
+    assert _parse_work({"title": []}) is None
+
+
+def test_parse_work_minimal():
+    paper = _parse_work({"title": ["Some Paper"], "DOI": "10.1234/test"})
+    assert paper is not None
+    assert paper.title == "Some Paper"
+    assert paper.doi == "10.1234/test"
+    assert paper.authors == []
+    assert paper.source_venue is None
+
+
+def test_parse_work_publication_date():
+    paper = _parse_work(SAMPLE_WORK)
+    assert paper is not None
+    assert paper.publication_date == "2010-6"

--- a/tests/test_clients/test_unpaywall.py
+++ b/tests/test_clients/test_unpaywall.py
@@ -1,0 +1,91 @@
+"""Tests for the Unpaywall API client."""
+
+from __future__ import annotations
+
+from opencite.clients.unpaywall import (
+    _extract_locations,
+    _parse_location,
+)
+
+# -- Unit tests for response parsing (no API needed) --
+
+SAMPLE_RESPONSE = {
+    "doi": "10.1523/jneurosci.3300-07.2008",
+    "is_oa": True,
+    "best_oa_location": {
+        "url_for_pdf": "https://europepmc.org/articles/pmc6671580?pdf=render",
+        "url_for_landing_page": "https://europepmc.org/articles/pmc6671580",
+        "version": "publishedVersion",
+        "license": "cc-by",
+    },
+    "oa_locations": [
+        {
+            "url_for_pdf": "https://europepmc.org/articles/pmc6671580?pdf=render",
+            "url_for_landing_page": "https://europepmc.org/articles/pmc6671580",
+            "version": "publishedVersion",
+            "license": "cc-by",
+        },
+        {
+            "url_for_pdf": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6671580/pdf/",
+            "version": "publishedVersion",
+            "license": None,
+        },
+        {
+            "url_for_pdf": None,
+            "url_for_landing_page": "https://doi.org/10.1523/jneurosci.3300-07.2008",
+            "version": "publishedVersion",
+        },
+    ],
+}
+
+
+def test_extract_locations_deduplicates():
+    """Best OA location should be first, duplicates removed."""
+    locs = _extract_locations(SAMPLE_RESPONSE)
+    urls = [loc.url for loc in locs]
+
+    assert len(locs) == 2  # 3rd has no PDF URL, 1st is deduped with best_oa
+    assert urls[0] == "https://europepmc.org/articles/pmc6671580?pdf=render"
+    assert urls[1] == "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6671580/pdf/"
+
+
+def test_extract_locations_all_oa():
+    """All extracted locations should be marked as OA."""
+    locs = _extract_locations(SAMPLE_RESPONSE)
+    assert all(loc.is_oa for loc in locs)
+    assert all(loc.source == "unpaywall" for loc in locs)
+
+
+def test_parse_location_with_pdf_url():
+    loc = _parse_location(
+        {
+            "url_for_pdf": "https://example.com/paper.pdf",
+            "version": "acceptedVersion",
+            "license": "cc-by-nc",
+        }
+    )
+    assert loc is not None
+    assert loc.url == "https://example.com/paper.pdf"
+    assert loc.version == "acceptedVersion"
+    assert loc.license == "cc-by-nc"
+
+
+def test_parse_location_no_pdf_url():
+    """Locations without pdf URL should return None."""
+    loc = _parse_location(
+        {
+            "url_for_pdf": None,
+            "url_for_landing_page": "https://example.com/",
+        }
+    )
+    assert loc is None
+
+
+def test_extract_locations_empty_response():
+    locs = _extract_locations({})
+    assert locs == []
+
+
+def test_extract_locations_no_oa():
+    locs = _extract_locations({"is_oa": False, "oa_locations": []})
+    assert locs == []

--- a/tests/test_clients/test_unpaywall.py
+++ b/tests/test_clients/test_unpaywall.py
@@ -44,9 +44,11 @@ def test_extract_locations_deduplicates():
     locs = _extract_locations(SAMPLE_RESPONSE)
     urls = [loc.url for loc in locs]
 
-    assert len(locs) == 2  # 3rd has no PDF URL, 1st is deduped with best_oa
+    # 3rd location falls back to landing page URL, 1st is deduped with best_oa
+    assert len(locs) == 3
     assert urls[0] == "https://europepmc.org/articles/pmc6671580?pdf=render"
     assert urls[1] == "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6671580/pdf/"
+    assert urls[2] == "https://doi.org/10.1523/jneurosci.3300-07.2008"
 
 
 def test_extract_locations_all_oa():
@@ -70,14 +72,21 @@ def test_parse_location_with_pdf_url():
     assert loc.license == "cc-by-nc"
 
 
-def test_parse_location_no_pdf_url():
-    """Locations without pdf URL should return None."""
+def test_parse_location_no_pdf_url_falls_back_to_landing():
+    """Locations without pdf URL should fall back to landing page."""
     loc = _parse_location(
         {
             "url_for_pdf": None,
             "url_for_landing_page": "https://example.com/",
         }
     )
+    assert loc is not None
+    assert loc.url == "https://example.com/"
+
+
+def test_parse_location_no_urls_at_all():
+    """Locations with neither pdf URL nor landing page return None."""
+    loc = _parse_location({"url_for_pdf": None, "url_for_landing_page": None})
     assert loc is None
 
 

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -2,18 +2,27 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
 from opencite.config import Config
 from opencite.models import Author, IDSet, Paper, PDFLocation
 from opencite.pdf import _PUBLISHER_MAP, PDFRetriever
 
 
-class TestCollectUrls:
-    def _make_retriever(self, **config_kwargs):
-        retriever = PDFRetriever.__new__(PDFRetriever)
-        retriever.config = Config(**config_kwargs)
-        return retriever
+def _make_retriever(**config_kwargs):
+    retriever = PDFRetriever.__new__(PDFRetriever)
+    retriever.config = Config(**config_kwargs)
+    # Mock the unpaywall client to avoid real API calls
+    retriever._unpaywall = MagicMock()
+    retriever._unpaywall.lookup_doi = AsyncMock(return_value=[])
+    return retriever
 
-    def test_pdf_locations_first(self):
+
+class TestCollectUrls:
+    @pytest.mark.asyncio
+    async def test_pdf_locations_first(self):
         paper = Paper(
             title="Test",
             ids=IDSet(doi="10.1234/test"),
@@ -21,39 +30,44 @@ class TestCollectUrls:
                 PDFLocation(url="https://example.com/paper.pdf", source="s2"),
             ],
         )
-        retriever = self._make_retriever()
-        urls = retriever._collect_urls(paper, "10.1234/test")
+        retriever = _make_retriever()
+        urls = await retriever._collect_urls(paper, "10.1234/test")
         assert urls[0] == "https://example.com/paper.pdf"
 
-    def test_pmc_url_added(self):
+    @pytest.mark.asyncio
+    async def test_pmc_url_added(self):
         paper = Paper(
             title="Test",
             ids=IDSet(pmcid="PMC12345"),
         )
-        retriever = self._make_retriever()
-        urls = retriever._collect_urls(paper, "PMC12345")
+        retriever = _make_retriever()
+        urls = await retriever._collect_urls(paper, "PMC12345")
         assert any("PMC12345" in u for u in urls)
 
-    def test_doi_url_added(self):
+    @pytest.mark.asyncio
+    async def test_doi_url_added(self):
         paper = Paper(
             title="Test",
             ids=IDSet(doi="10.1234/test"),
         )
-        retriever = self._make_retriever()
-        urls = retriever._collect_urls(paper, "10.1234/test")
+        retriever = _make_retriever()
+        urls = await retriever._collect_urls(paper, "10.1234/test")
         assert "https://doi.org/10.1234/test" in urls
 
-    def test_no_paper_doi_fallback(self):
-        retriever = self._make_retriever()
-        urls = retriever._collect_urls(None, "10.1234/test")
+    @pytest.mark.asyncio
+    async def test_no_paper_doi_fallback(self):
+        retriever = _make_retriever()
+        urls = await retriever._collect_urls(None, "10.1234/test")
         assert "https://doi.org/10.1234/test" in urls
 
-    def test_no_paper_non_doi(self):
-        retriever = self._make_retriever()
-        urls = retriever._collect_urls(None, "some_invalid_id")
+    @pytest.mark.asyncio
+    async def test_no_paper_non_doi(self):
+        retriever = _make_retriever()
+        urls = await retriever._collect_urls(None, "some_invalid_id")
         assert urls == []
 
-    def test_no_duplicate_urls(self):
+    @pytest.mark.asyncio
+    async def test_no_duplicate_urls(self):
         paper = Paper(
             title="Test",
             ids=IDSet(doi="10.1234/test"),
@@ -61,53 +75,54 @@ class TestCollectUrls:
                 PDFLocation(url="https://doi.org/10.1234/test", source="doi"),
             ],
         )
-        retriever = self._make_retriever()
-        urls = retriever._collect_urls(paper, "10.1234/test")
+        retriever = _make_retriever()
+        urls = await retriever._collect_urls(paper, "10.1234/test")
         assert urls.count("https://doi.org/10.1234/test") == 1
 
 
 class TestPublisherUrls:
-    def _make_retriever(self, **config_kwargs):
-        retriever = PDFRetriever.__new__(PDFRetriever)
-        retriever.config = Config(**config_kwargs)
-        return retriever
-
-    def test_elsevier_url_added_with_key(self):
-        retriever = self._make_retriever(elsevier_api_key="els_test")
+    @pytest.mark.asyncio
+    async def test_elsevier_url_added_with_key(self):
+        retriever = _make_retriever(elsevier_api_key="els_test")
         paper = Paper(title="Test", ids=IDSet(doi="10.1016/j.test.2024"))
-        urls = retriever._collect_urls(paper, "10.1016/j.test.2024")
+        urls = await retriever._collect_urls(paper, "10.1016/j.test.2024")
         assert any("api.elsevier.com" in u for u in urls)
         # Publisher URL should be first (highest priority)
         assert "api.elsevier.com" in urls[0]
 
-    def test_elsevier_url_not_added_without_key(self):
-        retriever = self._make_retriever()
+    @pytest.mark.asyncio
+    async def test_elsevier_url_not_added_without_key(self):
+        retriever = _make_retriever()
         paper = Paper(title="Test", ids=IDSet(doi="10.1016/j.test.2024"))
-        urls = retriever._collect_urls(paper, "10.1016/j.test.2024")
+        urls = await retriever._collect_urls(paper, "10.1016/j.test.2024")
         assert not any("api.elsevier.com" in u for u in urls)
 
-    def test_wiley_url_added_with_key(self):
-        retriever = self._make_retriever(wiley_tdm_token="wiley_test")
+    @pytest.mark.asyncio
+    async def test_wiley_url_added_with_key(self):
+        retriever = _make_retriever(wiley_tdm_token="wiley_test")
         paper = Paper(title="Test", ids=IDSet(doi="10.1002/test.123"))
-        urls = retriever._collect_urls(paper, "10.1002/test.123")
+        urls = await retriever._collect_urls(paper, "10.1002/test.123")
         assert any("api.wiley.com" in u for u in urls)
 
-    def test_springer_url_added_with_key(self):
-        retriever = self._make_retriever(springer_api_key="springer_test")
+    @pytest.mark.asyncio
+    async def test_springer_url_added_with_key(self):
+        retriever = _make_retriever(springer_api_key="springer_test")
         paper = Paper(title="Test", ids=IDSet(doi="10.1007/s123-test"))
-        urls = retriever._collect_urls(paper, "10.1007/s123-test")
+        urls = await retriever._collect_urls(paper, "10.1007/s123-test")
         assert any("api.springernature.com" in u for u in urls)
 
-    def test_springer_nature_prefix(self):
-        retriever = self._make_retriever(springer_api_key="springer_test")
+    @pytest.mark.asyncio
+    async def test_springer_nature_prefix(self):
+        retriever = _make_retriever(springer_api_key="springer_test")
         paper = Paper(title="Test", ids=IDSet(doi="10.1038/nature12345"))
-        urls = retriever._collect_urls(paper, "10.1038/nature12345")
+        urls = await retriever._collect_urls(paper, "10.1038/nature12345")
         assert any("api.springernature.com" in u for u in urls)
 
-    def test_unknown_publisher_no_extra_urls(self):
-        retriever = self._make_retriever(elsevier_api_key="test")
+    @pytest.mark.asyncio
+    async def test_unknown_publisher_no_extra_urls(self):
+        retriever = _make_retriever(elsevier_api_key="test")
         paper = Paper(title="Test", ids=IDSet(doi="10.9999/unknown"))
-        urls = retriever._collect_urls(paper, "10.9999/unknown")
+        urls = await retriever._collect_urls(paper, "10.9999/unknown")
         assert not any("api.elsevier.com" in u for u in urls)
         assert not any("api.wiley.com" in u for u in urls)
 
@@ -115,18 +130,15 @@ class TestPublisherUrls:
 class TestArXivBioRxivURLs:
     """Tests for direct preprint download URL injection."""
 
-    def _make_retriever(self, **config_kwargs):
-        retriever = PDFRetriever.__new__(PDFRetriever)
-        retriever.config = Config(**config_kwargs)
-        return retriever
-
-    def test_arxiv_pdf_url_added_from_arxiv_id(self):
+    @pytest.mark.asyncio
+    async def test_arxiv_pdf_url_added_from_arxiv_id(self):
         paper = Paper(title="Test", ids=IDSet(arxiv_id="1706.03762"))
-        retriever = self._make_retriever()
-        urls = retriever._collect_urls(paper, "1706.03762")
+        retriever = _make_retriever()
+        urls = await retriever._collect_urls(paper, "1706.03762")
         assert "https://arxiv.org/pdf/1706.03762" in urls
 
-    def test_arxiv_pdf_url_not_duplicated(self):
+    @pytest.mark.asyncio
+    async def test_arxiv_pdf_url_not_duplicated(self):
         paper = Paper(
             title="Test",
             ids=IDSet(arxiv_id="1706.03762"),
@@ -134,34 +146,38 @@ class TestArXivBioRxivURLs:
                 PDFLocation(url="https://arxiv.org/pdf/1706.03762", source="arxiv"),
             ],
         )
-        retriever = self._make_retriever()
-        urls = retriever._collect_urls(paper, "1706.03762")
+        retriever = _make_retriever()
+        urls = await retriever._collect_urls(paper, "1706.03762")
         assert urls.count("https://arxiv.org/pdf/1706.03762") == 1
 
-    def test_biorxiv_pdf_url_added_for_10_1101_doi(self):
+    @pytest.mark.asyncio
+    async def test_biorxiv_pdf_url_added_for_10_1101_doi(self):
         paper = Paper(title="Test", ids=IDSet(doi="10.1101/837021"))
-        retriever = self._make_retriever()
-        urls = retriever._collect_urls(paper, "10.1101/837021")
+        retriever = _make_retriever()
+        urls = await retriever._collect_urls(paper, "10.1101/837021")
         biorxiv_urls = [u for u in urls if "biorxiv.org" in u]
         assert len(biorxiv_urls) == 1
         assert "10.1101/837021" in biorxiv_urls[0]
 
-    def test_biorxiv_pdf_url_before_doi_negotiation(self):
+    @pytest.mark.asyncio
+    async def test_biorxiv_pdf_url_before_doi_negotiation(self):
         """Direct bioRxiv URL should appear before generic DOI URL."""
         paper = Paper(title="Test", ids=IDSet(doi="10.1101/837021"))
-        retriever = self._make_retriever()
-        urls = retriever._collect_urls(paper, "10.1101/837021")
+        retriever = _make_retriever()
+        urls = await retriever._collect_urls(paper, "10.1101/837021")
         biorxiv_idx = next(i for i, u in enumerate(urls) if "biorxiv.org" in u)
         doi_idx = next(i for i, u in enumerate(urls) if "doi.org" in u)
         assert biorxiv_idx < doi_idx
 
-    def test_non_biorxiv_doi_has_no_biorxiv_url(self):
+    @pytest.mark.asyncio
+    async def test_non_biorxiv_doi_has_no_biorxiv_url(self):
         paper = Paper(title="Test", ids=IDSet(doi="10.1038/nature12345"))
-        retriever = self._make_retriever()
-        urls = retriever._collect_urls(paper, "10.1038/nature12345")
+        retriever = _make_retriever()
+        urls = await retriever._collect_urls(paper, "10.1038/nature12345")
         assert not any("biorxiv.org" in u for u in urls)
 
-    def test_medrxiv_url_used_when_data_source_is_medrxiv(self):
+    @pytest.mark.asyncio
+    async def test_medrxiv_url_used_when_data_source_is_medrxiv(self):
         """Papers with medrxiv in data_sources get medrxiv.org URL, not biorxiv.org."""
         from opencite.models import Source
 
@@ -171,8 +187,8 @@ class TestArXivBioRxivURLs:
             data_sources={"medrxiv"},
             source_venue=Source(name="medRxiv", is_oa=True),
         )
-        retriever = self._make_retriever()
-        urls = retriever._collect_urls(paper, "10.1101/2021.01.01.12345")
+        retriever = _make_retriever()
+        urls = await retriever._collect_urls(paper, "10.1101/2021.01.01.12345")
         medrxiv_urls = [u for u in urls if "medrxiv.org" in u]
         assert len(medrxiv_urls) == 1
         assert not any("biorxiv.org" in u for u in urls)
@@ -203,29 +219,25 @@ class TestReportFailures:
             retriever._report_failures("10.1234/test", [], None)
         assert "All PDF download attempts failed" in caplog.text
 
-    def test_failures_with_reasons(self, caplog):
-        import logging
-
+    def test_failures_with_reasons(self, capsys):
         retriever = self._make_retriever()
         failures = [
             ("https://example.com/paper.pdf", "403 Forbidden/Unauthorized"),
             ("https://doi.org/10.1234/test", "timeout"),
         ]
-        with caplog.at_level(logging.WARNING):
-            retriever._report_failures("10.1234/test", failures, None)
-        assert "Tried 2 source(s)" in caplog.text
-        assert "403 Forbidden" in caplog.text
-        assert "timeout" in caplog.text
+        retriever._report_failures("10.1234/test", failures, None)
+        captured = capsys.readouterr()
+        assert "Tried 2 source(s)" in captured.err
+        assert "403 Forbidden" in captured.err
+        assert "timeout" in captured.err
 
-    def test_suggests_institutional_access(self, caplog):
-        import logging
-
+    def test_suggests_institutional_access(self, capsys):
         retriever = self._make_retriever()
         paper = Paper(title="Test", ids=IDSet(doi="10.1234/test"))
         failures = [("https://example.com", "404 Not Found")]
-        with caplog.at_level(logging.INFO):
-            retriever._report_failures("10.1234/test", failures, paper)
-        assert "institutional access" in caplog.text
+        retriever._report_failures("10.1234/test", failures, paper)
+        captured = capsys.readouterr()
+        assert "Institutional access" in captured.err
 
 
 class TestMakeFilename:
@@ -287,34 +299,26 @@ class TestReportFailuresEdgeCases:
         retriever.config = Config()
         return retriever
 
-    def test_institutional_access_from_identifier(self, caplog):
+    def test_institutional_access_from_identifier(self, capsys):
         """When paper has no DOI but identifier is a DOI, suggest access."""
-        import logging
-
         retriever = self._make_retriever()
         failures = [("https://example.com", "404")]
-        with caplog.at_level(logging.INFO):
-            retriever._report_failures("10.1234/test", failures, None)
-        assert "institutional access" in caplog.text
+        retriever._report_failures("10.1234/test", failures, None)
+        captured = capsys.readouterr()
+        assert "Institutional access" in captured.err
 
-    def test_no_institutional_suggestion_for_non_doi(self, caplog):
+    def test_no_institutional_suggestion_for_non_doi(self, capsys):
         """When identifier is not a DOI, no institutional suggestion."""
-        import logging
-
         retriever = self._make_retriever()
         failures = [("https://example.com", "404")]
-        with caplog.at_level(logging.INFO):
-            retriever._report_failures("some_random_id", failures, None)
-        assert "institutional access" not in caplog.text
+        retriever._report_failures("some_random_id", failures, None)
+        captured = capsys.readouterr()
+        assert "Institutional access" not in captured.err
 
 
 class TestCollectUrlsEdgeCases:
-    def _make_retriever(self, **config_kwargs):
-        retriever = PDFRetriever.__new__(PDFRetriever)
-        retriever.config = Config(**config_kwargs)
-        return retriever
-
-    def test_multiple_pdf_locations(self):
+    @pytest.mark.asyncio
+    async def test_multiple_pdf_locations(self):
         paper = Paper(
             title="Test",
             ids=IDSet(doi="10.1234/test"),
@@ -323,19 +327,53 @@ class TestCollectUrlsEdgeCases:
                 PDFLocation(url="https://b.pdf", source="openalex"),
             ],
         )
-        retriever = self._make_retriever()
-        urls = retriever._collect_urls(paper, "10.1234/test")
+        retriever = _make_retriever()
+        urls = await retriever._collect_urls(paper, "10.1234/test")
         assert "https://a.pdf" in urls
         assert "https://b.pdf" in urls
 
-    def test_identifier_parsed_when_no_paper(self):
+    @pytest.mark.asyncio
+    async def test_identifier_parsed_when_no_paper(self):
         """When paper is None, DOI is extracted from identifier."""
-        retriever = self._make_retriever()
-        urls = retriever._collect_urls(None, "10.1234/test")
+        retriever = _make_retriever()
+        urls = await retriever._collect_urls(None, "10.1234/test")
         assert "https://doi.org/10.1234/test" in urls
 
-    def test_identifier_pmid_no_urls(self):
+    @pytest.mark.asyncio
+    async def test_identifier_pmid_no_urls(self):
         """A PMID with no paper produces no URLs (no DOI to negotiate)."""
-        retriever = self._make_retriever()
-        urls = retriever._collect_urls(None, "pmid:12345")
+        retriever = _make_retriever()
+        urls = await retriever._collect_urls(None, "pmid:12345")
         assert urls == []
+
+
+class TestUnpaywallIntegration:
+    """Test that Unpaywall URLs are included in the PDF pipeline."""
+
+    @pytest.mark.asyncio
+    async def test_unpaywall_urls_added(self):
+        """Unpaywall locations should appear in the URL list."""
+        retriever = _make_retriever()
+        # Mock unpaywall returning OA locations
+        retriever._unpaywall.lookup_doi = AsyncMock(
+            return_value=[
+                PDFLocation(
+                    url="https://europepmc.org/articles/pmc123?pdf=render",
+                    source="unpaywall",
+                    is_oa=True,
+                ),
+            ]
+        )
+        paper = Paper(title="Test", ids=IDSet(doi="10.1234/test"))
+        urls = await retriever._collect_urls(paper, "10.1234/test")
+        assert "https://europepmc.org/articles/pmc123?pdf=render" in urls
+
+    @pytest.mark.asyncio
+    async def test_unpaywall_failure_doesnt_break_pipeline(self):
+        """If Unpaywall fails, other sources still work."""
+        retriever = _make_retriever()
+        retriever._unpaywall.lookup_doi = AsyncMock(side_effect=Exception("timeout"))
+        paper = Paper(title="Test", ids=IDSet(doi="10.1234/test"))
+        urls = await retriever._collect_urls(paper, "10.1234/test")
+        # Should still have DOI URL at minimum
+        assert "https://doi.org/10.1234/test" in urls

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -211,13 +211,11 @@ class TestReportFailures:
         retriever.config = Config()
         return retriever
 
-    def test_empty_failures(self, caplog):
-        import logging
-
+    def test_empty_failures(self, capsys):
         retriever = self._make_retriever()
-        with caplog.at_level(logging.WARNING):
-            retriever._report_failures("10.1234/test", [], None)
-        assert "All PDF download attempts failed" in caplog.text
+        retriever._report_failures("10.1234/test", [], None)
+        captured = capsys.readouterr()
+        assert "no sources attempted" in captured.err
 
     def test_failures_with_reasons(self, capsys):
         retriever = self._make_retriever()


### PR DESCRIPTION
Add three new academic source integrations to improve paper discovery
and PDF retrieval:

- Unpaywall: finds OA PDF copies by DOI across 50k+ repositories (no
  API key needed, just contact_email). Integrated into PDF pipeline as
  priority source before DOI content negotiation.
- CrossRef: authoritative DOI metadata registry (150M+ works). Provides
  keyword search, DOI lookup fallback, and PDF link extraction. No API
  key required.
- CORE: OA full-text aggregator (300M+ records, 40M+ full texts).
  Provides search and DOI lookup with direct download URLs. Requires
  free API key.

Fix Issue #21 (pdf command fails silently):
- Report PDF download failures to stderr with per-source details,
  regardless of log level
- Show publisher-specific hints (e.g. "Set elsevier_api_key" for
  Elsevier DOIs, "check Unpaywall" for IEEE)
- Add PUBLISHER_INFO mapping for 25+ major publishers with retrieval
  strategy guidance

Integration:
- SearchOrchestrator now searches CrossRef and CORE in parallel with
  existing 5 sources
- DOI lookup falls back to CrossRef when S2 and OpenAlex miss
- PDF pipeline queries Unpaywall for OA copies before DOI negotiation
- CLI --source choices updated to include crossref and core
- Config updated with core_api_key, rate limits for new sources

Tests: 23 new unit tests for response parsing across all 3 clients,
updated test_pdf.py for async _collect_urls and Unpaywall integration.

https://claude.ai/code/session_019FksnuFquqgiHhXrzdWGwY