### PR TITLE
Phase 2: HTML/JATS full-text pipeline

### DIFF
--- a/src/opencite/batch.py
+++ b/src/opencite/batch.py
@@ -196,7 +196,7 @@ async def batch_download(
         pre_retriever: PreprintFullTextRetriever,
     ) -> Path | None:
         """Try preprint-native HTML retrieval for arXiv/bioRxiv/medRxiv DOIs."""
-        return await pre_retriever.retrieve_for_doi(
+        return await pre_retriever.retrieve_for_identifier(
             identifier,
             output_dir=str(md_dir),
         )

--- a/src/opencite/batch.py
+++ b/src/opencite/batch.py
@@ -15,6 +15,7 @@ from opencite.pdf import PDFRetriever
 if TYPE_CHECKING:
     from opencite.config import Config
     from opencite.fulltext import FullTextRetriever
+    from opencite.preprint_fulltext import PreprintFullTextRetriever
 
 logger = logging.getLogger(__name__)
 
@@ -135,12 +136,15 @@ async def batch_download(
     converter: str = "auto",
     concurrency: int = 3,
     prefer_fulltext: bool = True,
+    prefer_preprint_html: bool = True,
 ) -> BatchResult:
     """Download PDFs for multiple papers with controlled concurrency.
 
-    When convert=True and prefer_fulltext=True, tries PMC full-text
-    retrieval first (bypassing PDF entirely). Falls back to PDF download
-    + conversion if full text is not available.
+    When convert=True, the retrieval order is:
+    1. PMC full text (if `prefer_fulltext`).
+    2. Preprint server HTML (ar5iv / .full) for arXiv/bioRxiv/medRxiv DOIs
+       (if `prefer_preprint_html`).
+    3. PDF download + markdown conversion.
 
     Args:
         ids: List of DOIs or other identifiers.
@@ -150,6 +154,8 @@ async def batch_download(
         converter: Converter to use for markdown conversion.
         concurrency: Max concurrent downloads.
         prefer_fulltext: Try PMC full-text before PDF when converting.
+        prefer_preprint_html: Try preprint-native HTML before PDF (arXiv,
+            bioRxiv, medRxiv).
 
     Returns:
         BatchResult with summary statistics.
@@ -185,8 +191,21 @@ async def batch_download(
             extract_images=True,
         )
 
+    async def _try_preprint_html(
+        identifier: str,
+        pre_retriever: PreprintFullTextRetriever,
+    ) -> Path | None:
+        """Try preprint-native HTML retrieval for arXiv/bioRxiv/medRxiv DOIs."""
+        return await pre_retriever.retrieve_for_doi(
+            identifier,
+            output_dir=str(md_dir),
+        )
+
     async def _process_one(
-        identifier: str, retriever: PDFRetriever, ft_retriever: FullTextRetriever | None
+        identifier: str,
+        retriever: PDFRetriever,
+        ft_retriever: FullTextRetriever | None,
+        pre_retriever: PreprintFullTextRetriever | None,
     ) -> None:
         async with semaphore:
             try:
@@ -198,6 +217,23 @@ async def batch_download(
                         result.converted += 1
                         print(
                             f"  OK (fulltext): {identifier} -> {md_path.name}",
+                            file=sys.stderr,
+                        )
+                        return
+
+                # Then try preprint-native HTML (ar5iv / .full).
+                if (
+                    convert
+                    and prefer_preprint_html
+                    and md_dir is not None
+                    and pre_retriever is not None
+                ):
+                    md_path = await _try_preprint_html(identifier, pre_retriever)
+                    if md_path:
+                        result.fulltext_retrieved += 1
+                        result.converted += 1
+                        print(
+                            f"  OK (preprint html): {identifier} -> {md_path.name}",
                             file=sys.stderr,
                         )
                         return
@@ -258,14 +294,27 @@ async def batch_download(
         ft_instance = _FTR(config)
         await ft_instance.__aenter__()
 
+    pre_instance: PreprintFullTextRetriever | None = None
+    if convert and prefer_preprint_html:
+        from opencite.preprint_fulltext import (
+            PreprintFullTextRetriever as _PreFTR,
+        )
+
+        pre_instance = _PreFTR(config)
+        await pre_instance.__aenter__()
+
     try:
         async with PDFRetriever(config) as retriever:
             tasks = [
-                asyncio.create_task(_process_one(id_, retriever, ft_instance))
+                asyncio.create_task(
+                    _process_one(id_, retriever, ft_instance, pre_instance)
+                )
                 for id_ in ids
             ]
             await asyncio.gather(*tasks)
     finally:
+        if pre_instance is not None:
+            await pre_instance.__aexit__()
         if ft_instance is not None:
             await ft_instance.__aexit__()
 

--- a/src/opencite/cli.py
+++ b/src/opencite/cli.py
@@ -145,6 +145,11 @@ def create_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="skip PMC full-text retrieval, force PDF download",
     )
+    pdf_p.add_argument(
+        "--no-preprint-html",
+        action="store_true",
+        help="skip preprint HTML routes (ar5iv, bioRxiv .full), force PDF download",
+    )
 
     # -- convert --
     convert_p = subparsers.add_parser("convert", help="convert a PDF to markdown")
@@ -209,6 +214,11 @@ def create_parser() -> argparse.ArgumentParser:
         "--no-fulltext",
         action="store_true",
         help="skip PMC full-text retrieval, force PDF download",
+    )
+    batch_p.add_argument(
+        "--no-preprint-html",
+        action="store_true",
+        help="skip preprint HTML routes (ar5iv, bioRxiv .full), force PDF download",
     )
 
     # -- config --
@@ -458,9 +468,9 @@ async def _cmd_pdf(args: argparse.Namespace, config: object) -> int:
     else:
         output_dir = output_val
 
-    # When --convert is used and --no-fulltext is not set, try PMC full-text
-    # first then fall back to PDF download + convert (all handled inside
-    # retrieve_as_markdown).
+    # When --convert is used, try PMC full text and preprint HTML before
+    # falling back to PDF download + convert. Both shortcuts are gated by
+    # their respective `--no-...` opt-out flags.
     if args.convert and not args.no_fulltext:
         async with PDFRetriever(config) as retriever:
             md_path = await retriever.retrieve_as_markdown(
@@ -469,6 +479,7 @@ async def _cmd_pdf(args: argparse.Namespace, config: object) -> int:
                 extract_images=True,
                 converter=args.converter,
                 filename=args.filename,
+                prefer_preprint_html=not args.no_preprint_html,
             )
         if md_path:
             print(f"Retrieved: {md_path}", file=sys.stderr)
@@ -585,6 +596,7 @@ async def _cmd_batch_fetch(args: argparse.Namespace, config: object) -> int:
         converter=args.converter,
         concurrency=args.concurrency,
         prefer_fulltext=not args.no_fulltext,
+        prefer_preprint_html=not args.no_preprint_html,
     )
 
     # Print summary

--- a/src/opencite/clients/_biorxiv_like.py
+++ b/src/opencite/clients/_biorxiv_like.py
@@ -68,11 +68,17 @@ class _BiorxivLikePreprintClient(PreprintClient):
 
     async def __aenter__(self) -> _BiorxivLikePreprintClient:
         await super().__aenter__()
-        self._crossref_client = httpx.AsyncClient(
-            base_url=_CROSSREF_BASE,
-            timeout=self.timeout,
-            headers=self._default_headers(),
-        )
+        try:
+            self._crossref_client = httpx.AsyncClient(
+                base_url=_CROSSREF_BASE,
+                timeout=self.timeout,
+                headers=self._default_headers(),
+            )
+        except Exception:
+            # The parent's session was opened above; close it before
+            # propagating so we don't leak the underlying httpx client.
+            await super().__aexit__()
+            raise
         return self
 
     async def __aexit__(self, *args: object) -> None:
@@ -233,7 +239,7 @@ class _BiorxivLikePreprintClient(PreprintClient):
             )
             return None
 
-        return html_to_markdown(resp.text)
+        return html_to_markdown(resp.text, context=f"{self.server}:{doi}")
 
     # ------------------------------------------------------------------
     # Parsing helpers

--- a/src/opencite/clients/_biorxiv_like.py
+++ b/src/opencite/clients/_biorxiv_like.py
@@ -21,7 +21,11 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 import httpx
 
-from opencite.clients.preprint_base import PreprintClient
+from opencite.clients.preprint_base import (
+    FulltextRoute,
+    PreprintClient,
+    html_to_markdown,
+)
 from opencite.exceptions import APIError
 from opencite.models import Author, IDSet, Paper, PDFLocation, Source
 
@@ -187,6 +191,49 @@ class _BiorxivLikePreprintClient(PreprintClient):
 
         entry = collection[-1]
         return self._parse_content_entry(entry)
+
+    # ------------------------------------------------------------------
+    # Full-text retrieval (bioRxiv/medRxiv .full HTML)
+    # ------------------------------------------------------------------
+
+    def fulltext_route(self, paper: Paper) -> FulltextRoute:
+        """`.full` HTML when a 10.1101/* DOI is present, else NONE."""
+        doi = (paper.doi or "").strip()
+        return FulltextRoute.HTML if doi.startswith("10.1101/") else FulltextRoute.NONE
+
+    async def fetch_fulltext(self, paper: Paper) -> str | None:
+        """Fetch the bioRxiv/medRxiv `.full` HTML and return markdown.
+
+        Both servers expose articles at
+        ``https://www.{server}.org/content/{doi}.full`` (the same URL as the
+        PDF route minus the ``.pdf``). Returns None on missing DOI, non-200
+        response, or markdown conversion failure.
+        """
+        doi = (paper.doi or "").strip()
+        if not doi.startswith("10.1101/"):
+            return None
+
+        if self._client is None:
+            raise RuntimeError("Client not initialized. Use 'async with'.")
+
+        url = f"https://www.{self.server}.org/content/{doi}.full"
+        try:
+            await self.rate_limiter.acquire()
+            resp = await self._client.get(url, follow_redirects=True)
+        except (httpx.HTTPError, httpx.TimeoutException) as e:
+            logger.warning("%s .full fetch failed for %s: %s", self.server, doi, e)
+            return None
+
+        if resp.status_code != 200:
+            logger.warning(
+                "%s .full returned HTTP %d for %s",
+                self.server,
+                resp.status_code,
+                doi,
+            )
+            return None
+
+        return html_to_markdown(resp.text)
 
     # ------------------------------------------------------------------
     # Parsing helpers

--- a/src/opencite/clients/arxiv.py
+++ b/src/opencite/clients/arxiv.py
@@ -148,7 +148,7 @@ class ArXivClient(PreprintClient):
             logger.warning("ar5iv returned HTTP %d for %s", resp.status_code, arxiv_id)
             return None
 
-        return html_to_markdown(resp.text)
+        return html_to_markdown(resp.text, context=f"arxiv:{arxiv_id}")
 
     @staticmethod
     def _derive_arxiv_id(paper: Paper) -> str:

--- a/src/opencite/clients/arxiv.py
+++ b/src/opencite/clients/arxiv.py
@@ -7,7 +7,13 @@ import re
 import xml.etree.ElementTree as ET
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from opencite.clients.preprint_base import PreprintClient
+import httpx
+
+from opencite.clients.preprint_base import (
+    FulltextRoute,
+    PreprintClient,
+    html_to_markdown,
+)
 from opencite.exceptions import APIError
 from opencite.models import Author, IDSet, Paper, PDFLocation, Source
 
@@ -17,6 +23,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 BASE_URL = "https://export.arxiv.org/api"
+AR5IV_BASE = "https://ar5iv.labs.arxiv.org"
 
 _ATOM_NS = "http://www.w3.org/2005/Atom"
 _ARXIV_NS = "http://arxiv.org/schemas/atom"
@@ -103,6 +110,55 @@ class ArXivClient(PreprintClient):
             return None
         arxiv_id = doi.strip()[len(_ARXIV_DOI_PREFIX) :]
         return await self.lookup_arxiv_id(arxiv_id)
+
+    # ------------------------------------------------------------------
+    # Full-text retrieval (ar5iv HTML5)
+    # ------------------------------------------------------------------
+
+    def fulltext_route(self, paper: Paper) -> FulltextRoute:
+        """Use ar5iv HTML when an arXiv ID can be derived from the paper."""
+        return (
+            FulltextRoute.HTML if self._derive_arxiv_id(paper) else FulltextRoute.NONE
+        )
+
+    async def fetch_fulltext(self, paper: Paper) -> str | None:
+        """Fetch the ar5iv HTML5 rendering of *paper* and return markdown.
+
+        ar5iv (https://ar5iv.labs.arxiv.org) renders LaTeX source as semantic
+        HTML5, which converts to markdown more cleanly than the PDF and
+        preserves equations as MathML. Returns None when the paper has no
+        derivable arXiv ID, the response is not 200, or conversion fails.
+        """
+        arxiv_id = self._derive_arxiv_id(paper)
+        if not arxiv_id:
+            return None
+
+        if self._client is None:
+            raise RuntimeError("Client not initialized. Use 'async with'.")
+
+        url = f"{AR5IV_BASE}/html/{arxiv_id}"
+        try:
+            await self.rate_limiter.acquire()
+            resp = await self._client.get(url, follow_redirects=True)
+        except (httpx.HTTPError, httpx.TimeoutException) as e:
+            logger.warning("ar5iv fetch failed for %s: %s", arxiv_id, e)
+            return None
+
+        if resp.status_code != 200:
+            logger.warning("ar5iv returned HTTP %d for %s", resp.status_code, arxiv_id)
+            return None
+
+        return html_to_markdown(resp.text)
+
+    @staticmethod
+    def _derive_arxiv_id(paper: Paper) -> str:
+        """Pull an arXiv ID out of `paper` via `ids.arxiv_id` or a Datacite DOI."""
+        if paper.ids.arxiv_id:
+            return paper.ids.arxiv_id.strip()
+        doi = (paper.doi or "").strip()
+        if doi.lower().startswith(_ARXIV_DOI_PREFIX):
+            return doi[len(_ARXIV_DOI_PREFIX) :]
+        return ""
 
     # ------------------------------------------------------------------
     # Parsing

--- a/src/opencite/clients/preprint_base.py
+++ b/src/opencite/clients/preprint_base.py
@@ -24,18 +24,25 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def html_to_markdown(html: str) -> str | None:
+def html_to_markdown(html: str, context: str = "") -> str | None:
     """Convert an HTML document to markdown using markitdown.
 
     markitdown is the same library used by the PDF pipeline (`convert.py`),
     so output style is consistent across full-text routes. Returns None on
     conversion failure.
+
+    Args:
+        html: The HTML body to convert.
+        context: Identifier (DOI, arXiv ID, or "scheme:value") included in
+            warning messages so failures are traceable to a specific paper.
     """
+    ctx = f" [{context}]" if context else ""
     try:
         from markitdown import MarkItDown
     except ImportError:
         logger.warning(
-            "markitdown is required for HTML-to-markdown conversion but is not installed"
+            "markitdown is required for HTML-to-markdown conversion but is not installed%s",
+            ctx,
         )
         return None
 
@@ -47,7 +54,7 @@ def html_to_markdown(html: str) -> str | None:
         )
         return result.text_content
     except (OSError, ValueError, RuntimeError) as e:
-        logger.warning("HTML-to-markdown conversion failed: %s", e)
+        logger.warning("HTML-to-markdown conversion failed%s: %s", ctx, e)
         return None
 
 

--- a/src/opencite/clients/preprint_base.py
+++ b/src/opencite/clients/preprint_base.py
@@ -4,20 +4,51 @@ Concrete subclasses (arXiv, bioRxiv, medRxiv, OSF/PsyArXiv, Zenodo, Figshare)
 share the same surface so the search orchestrator and full-text dispatcher
 can treat them uniformly.
 
-Phase 1 introduces the surface only; Phase 2 wires up `fulltext_route` /
-`fetch_fulltext` for each subclass.
+Phase 1 introduces the surface; Phase 2 fills in `fulltext_route` /
+`fetch_fulltext` for arXiv (ar5iv HTML5) and bioRxiv/medRxiv (.full HTML).
 """
 
 from __future__ import annotations
 
+import logging
 from abc import ABC, abstractmethod
 from enum import StrEnum
+from io import BytesIO
 from typing import TYPE_CHECKING, ClassVar
 
 from opencite.clients.base import BaseClient
 
 if TYPE_CHECKING:
     from opencite.models import Paper
+
+logger = logging.getLogger(__name__)
+
+
+def html_to_markdown(html: str) -> str | None:
+    """Convert an HTML document to markdown using markitdown.
+
+    markitdown is the same library used by the PDF pipeline (`convert.py`),
+    so output style is consistent across full-text routes. Returns None on
+    conversion failure.
+    """
+    try:
+        from markitdown import MarkItDown
+    except ImportError:
+        logger.warning(
+            "markitdown is required for HTML-to-markdown conversion but is not installed"
+        )
+        return None
+
+    try:
+        converter = MarkItDown()
+        result = converter.convert_stream(
+            BytesIO(html.encode("utf-8")),
+            file_extension=".html",
+        )
+        return result.text_content
+    except (OSError, ValueError, RuntimeError) as e:
+        logger.warning("HTML-to-markdown conversion failed: %s", e)
+        return None
 
 
 class FulltextRoute(StrEnum):

--- a/src/opencite/pdf.py
+++ b/src/opencite/pdf.py
@@ -382,8 +382,9 @@ class PDFRetriever:
         extract_images: bool = True,
         converter: str = "auto",
         filename: str | None = None,
+        prefer_preprint_html: bool = True,
     ) -> Path | None:
-        """Try PMC full-text first, then fall back to PDF download + convert.
+        """Try PMC full-text, then preprint HTML, then fall back to PDF + convert.
 
         Args:
             identifier: DOI or other paper identifier.
@@ -392,11 +393,14 @@ class PDFRetriever:
             extract_images: Whether to extract/download images.
             converter: Converter for PDF fallback ("auto", "markitdown", "mistral").
             filename: Custom base filename (without extension).
+            prefer_preprint_html: When True, try the preprint server's HTML
+                route (ar5iv for arXiv, .full for bioRxiv/medRxiv) before PDF.
 
         Returns:
             Path to the markdown file, or None if all methods fail.
         """
         from opencite.fulltext import FullTextRetriever
+        from opencite.preprint_fulltext import PreprintFullTextRetriever
 
         # If no paper provided, try to get metadata
         if paper is None:
@@ -415,8 +419,26 @@ class PDFRetriever:
                 logger.info("Retrieved full text from PMC for %s", identifier)
                 return md_path
 
+        # Try preprint-native HTML (ar5iv / bioRxiv .full) before downloading a PDF.
+        if prefer_preprint_html and paper is not None:
+            async with PreprintFullTextRetriever(self.config) as pre:
+                md_path = await pre.retrieve(
+                    paper,
+                    output_dir=output_dir,
+                    identifier=identifier,
+                    filename=filename,
+                )
+                if md_path:
+                    logger.info(
+                        "Retrieved preprint full text (HTML) for %s", identifier
+                    )
+                    return md_path
+
         # Fall back to PDF download + conversion
-        logger.debug("PMC full text not available for %s, trying PDF", identifier)
+        logger.debug(
+            "PMC and preprint HTML full text unavailable for %s, trying PDF",
+            identifier,
+        )
         pdf_path = await self.download(
             identifier=identifier,
             output_dir=output_dir,

--- a/src/opencite/preprint_fulltext.py
+++ b/src/opencite/preprint_fulltext.py
@@ -56,13 +56,30 @@ class PreprintFullTextRetriever:
         self._by_name: dict[str, PreprintClient] = {c.name: c for c in self._clients}
 
     async def __aenter__(self) -> PreprintFullTextRetriever:
-        for client in self._clients:
-            await client.__aenter__()
+        entered: list[PreprintClient] = []
+        try:
+            for client in self._clients:
+                await client.__aenter__()
+                entered.append(client)
+        except Exception:
+            # Roll back the partial enter so we don't leak open httpx clients
+            # for the subset that successfully opened.
+            for c in reversed(entered):
+                try:
+                    await c.__aexit__()
+                except Exception:
+                    logger.warning(
+                        "Failed to roll back %s during retriever init", c.name
+                    )
+            raise
         return self
 
     async def __aexit__(self, *args: object) -> None:
         for client in self._clients:
-            await client.__aexit__(*args)
+            try:
+                await client.__aexit__(*args)
+            except Exception:
+                logger.warning("Error closing preprint client %s", client.name)
 
     def _pick_client(self, paper: Paper) -> PreprintClient | None:
         """Return the preprint client that can serve *paper*, or None."""
@@ -72,7 +89,14 @@ class PreprintFullTextRetriever:
             if client is not None:
                 return client
 
-        # 2. DOI-prefix routing.
+        # 2. arXiv ID -> arXiv client (covers bare arXiv IDs and ``arxiv:`` URLs
+        #    where no DOI is on the paper yet).
+        if paper.ids.arxiv_id:
+            client = self._by_name.get("arxiv")
+            if client is not None:
+                return client
+
+        # 3. DOI-prefix routing.
         doi = (paper.doi or "").strip().lower()
         if not doi:
             return None
@@ -108,16 +132,36 @@ class PreprintFullTextRetriever:
             Path to the written markdown file, or None when no preprint
             route applies / fetch fails / conversion fails.
         """
+        ident_for_log = identifier or paper.doi or paper.ids.arxiv_id or "<unknown>"
+
         client = self._pick_client(paper)
         if client is None:
+            logger.debug(
+                "no preprint client for %s (doi=%s, arxiv_id=%s, sources=%s)",
+                ident_for_log,
+                paper.doi,
+                paper.ids.arxiv_id,
+                paper.data_sources,
+            )
             return None
 
         route = client.fulltext_route(paper)
         if route in (FulltextRoute.NONE, FulltextRoute.PDF):
+            logger.debug(
+                "preprint route %s for %s via %s -> skip",
+                route,
+                ident_for_log,
+                client.name,
+            )
             return None
 
         md_text = await client.fetch_fulltext(paper)
         if not md_text:
+            logger.debug(
+                "preprint fetch returned empty markdown for %s via %s",
+                ident_for_log,
+                client.name,
+            )
             return None
 
         out_dir = Path(output_dir)
@@ -137,24 +181,44 @@ class PreprintFullTextRetriever:
         )
         return md_path
 
-    async def retrieve_for_doi(
+    async def retrieve_for_identifier(
         self,
-        doi: str,
+        identifier: str,
         output_dir: str | Path = ".",
         filename: str | None = None,
     ) -> Path | None:
-        """DOI-only entry point: looks up the paper, then retrieves full text.
+        """Identifier-only entry point: parses the identifier, retrieves full text.
 
-        Used by `batch.py` and the `pdf` CLI subcommand when only an
-        identifier is available.
+        Accepts any identifier `parse_identifier` understands -- bare DOIs,
+        ``arxiv:XXXX.YYYYY``, ``pmid:XXXXX``, full URLs to arXiv/bioRxiv, etc.
+        Maps it to the right `IDSet` field so `_pick_client` can route by
+        either ``arxiv_id`` or ``doi``. Used by `batch.py` and the `pdf` CLI
+        subcommand when only a free-form identifier is available.
         """
-        from opencite.models import IDSet
+        from opencite.models import IDSet, IDType, parse_identifier
         from opencite.models import Paper as PaperModel
 
-        paper = PaperModel(title="", ids=IDSet(doi=doi))
+        ids: IDSet
+        try:
+            id_type, id_value = parse_identifier(identifier)
+        except ValueError:
+            ids = IDSet(doi=identifier)
+        else:
+            if id_type == IDType.ARXIV:
+                ids = IDSet(arxiv_id=id_value)
+            elif id_type == IDType.DOI:
+                ids = IDSet(doi=id_value)
+            elif id_type == IDType.PMID:
+                ids = IDSet(pmid=id_value)
+            elif id_type == IDType.PMCID:
+                ids = IDSet(pmcid=id_value)
+            else:
+                ids = IDSet(doi=identifier)
+
+        paper = PaperModel(title="", ids=ids)
         return await self.retrieve(
             paper,
             output_dir=output_dir,
-            identifier=doi,
+            identifier=identifier,
             filename=filename,
         )

--- a/src/opencite/preprint_fulltext.py
+++ b/src/opencite/preprint_fulltext.py
@@ -1,0 +1,160 @@
+"""Preprint full-text retrieval pipeline.
+
+Sits between :class:`opencite.fulltext.FullTextRetriever` (PMC BioC) and the
+PDF download path. For OA preprints, fetches the server-native HTML/JATS
+representation and converts it to markdown so the user does not pay the
+quality and bandwidth cost of a PDF round-trip.
+
+Phase 2 ships the arXiv (ar5iv HTML5) and bioRxiv/medRxiv (`.full` HTML)
+routes; Phase 3 will plug in OSF/PsyArXiv, Zenodo, and Figshare.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from opencite.clients.arxiv import ArXivClient
+from opencite.clients.biorxiv import BioRxivClient
+from opencite.clients.medrxiv import MedRxivClient
+from opencite.clients.preprint_base import FulltextRoute, PreprintClient
+from opencite.utils import make_paper_filename
+
+if TYPE_CHECKING:
+    from opencite.config import Config
+    from opencite.models import Paper
+
+logger = logging.getLogger(__name__)
+
+
+class PreprintFullTextRetriever:
+    """Retrieve preprint full text via the matching `PreprintClient`.
+
+    Picks the right client for a paper using two signals, in order:
+
+    1. ``paper.data_sources`` matches a client's ``name`` (e.g. ``"arxiv"``).
+    2. ``paper.doi`` prefix matches a known preprint DOI prefix
+       (``10.48550/arXiv.`` -> arxiv; ``10.1101/`` -> biorxiv then medrxiv).
+
+    Mirrors the shape of :class:`opencite.fulltext.FullTextRetriever` so
+    callers in `pdf.py` and `batch.py` can chain them with parallel structure.
+    """
+
+    def __init__(
+        self,
+        config: Config,
+        clients: list[PreprintClient] | None = None,
+    ) -> None:
+        self.config = config
+        # Default fan-out covers Phase 1+2 servers. Phase 3 extends this list.
+        self._clients: list[PreprintClient] = clients or [
+            ArXivClient(config),
+            BioRxivClient(config),
+            MedRxivClient(config),
+        ]
+        self._by_name: dict[str, PreprintClient] = {c.name: c for c in self._clients}
+
+    async def __aenter__(self) -> PreprintFullTextRetriever:
+        for client in self._clients:
+            await client.__aenter__()
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        for client in self._clients:
+            await client.__aexit__(*args)
+
+    def _pick_client(self, paper: Paper) -> PreprintClient | None:
+        """Return the preprint client that can serve *paper*, or None."""
+        # 1. Direct attribution on the paper.
+        for src in paper.data_sources:
+            client = self._by_name.get(src)
+            if client is not None:
+                return client
+
+        # 2. DOI-prefix routing.
+        doi = (paper.doi or "").strip().lower()
+        if not doi:
+            return None
+        if doi.startswith("10.48550/arxiv."):
+            return self._by_name.get("arxiv")
+        if doi.startswith("10.1101/"):
+            # bioRxiv first; medRxiv as fallback. Both will return None for
+            # the wrong server, so the orchestrator above us would have to
+            # try multiple. Here we pick ONE client to fetch full text from
+            # and rely on the .full URL succeeding. bioRxiv fronting is fine
+            # because bioRxiv mirrors medRxiv content URLs cross-domain in
+            # practice; if it 404s we return None and the caller falls back
+            # to PDF.
+            return self._by_name.get("biorxiv") or self._by_name.get("medrxiv")
+        return None
+
+    async def retrieve(
+        self,
+        paper: Paper,
+        output_dir: str | Path = ".",
+        identifier: str | None = None,
+        filename: str | None = None,
+    ) -> Path | None:
+        """Fetch full text for *paper* and write markdown to disk.
+
+        Args:
+            paper: The paper to retrieve. Must carry a DOI or arXiv ID.
+            output_dir: Directory for the markdown file (created if missing).
+            identifier: Original CLI identifier, used for filename fallback.
+            filename: Custom base filename (without extension).
+
+        Returns:
+            Path to the written markdown file, or None when no preprint
+            route applies / fetch fails / conversion fails.
+        """
+        client = self._pick_client(paper)
+        if client is None:
+            return None
+
+        route = client.fulltext_route(paper)
+        if route in (FulltextRoute.NONE, FulltextRoute.PDF):
+            return None
+
+        md_text = await client.fetch_fulltext(paper)
+        if not md_text:
+            return None
+
+        out_dir = Path(output_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        ident_for_name = identifier or paper.doi or paper.ids.arxiv_id or ""
+        fname = filename or make_paper_filename(paper, ident_for_name)
+        if not fname.endswith(".md"):
+            fname += ".md"
+        md_path = out_dir / fname
+        md_path.write_text(md_text, encoding="utf-8")
+        logger.info(
+            "Preprint full text written to %s via %s (%s)",
+            md_path,
+            client.name,
+            route,
+        )
+        return md_path
+
+    async def retrieve_for_doi(
+        self,
+        doi: str,
+        output_dir: str | Path = ".",
+        filename: str | None = None,
+    ) -> Path | None:
+        """DOI-only entry point: looks up the paper, then retrieves full text.
+
+        Used by `batch.py` and the `pdf` CLI subcommand when only an
+        identifier is available.
+        """
+        from opencite.models import IDSet
+        from opencite.models import Paper as PaperModel
+
+        paper = PaperModel(title="", ids=IDSet(doi=doi))
+        return await self.retrieve(
+            paper,
+            output_dir=output_dir,
+            identifier=doi,
+            filename=filename,
+        )

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -3,16 +3,19 @@
 from __future__ import annotations
 
 import json
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from opencite.batch import (
     BatchResult,
+    batch_download,
     prepare_output_dirs,
     read_ids_from_file,
     read_ids_from_json,
     read_ids_from_stdin,
 )
+from opencite.config import Config
 
 
 class TestBatchResult:
@@ -210,3 +213,87 @@ class TestPrepareOutputDirs:
         assert pdf1 == pdf2
         assert md1 == md2
         assert img1 == img2
+
+
+class TestBatchPreprintIntegration:
+    """`batch_download` should try preprint HTML before PDF when converting.
+
+    Stub the retrievers and the PDFRetriever lifecycle so the wiring is
+    exercised without hitting the network or the real PDF pipeline.
+    """
+
+    @pytest.mark.asyncio
+    async def test_preprint_html_path_used_when_available(self, tmp_path, monkeypatch):
+        pdf_instance = MagicMock()
+        pdf_instance.__aenter__ = AsyncMock(return_value=pdf_instance)
+        pdf_instance.__aexit__ = AsyncMock(return_value=None)
+        pdf_instance.download = AsyncMock()
+        import opencite.batch as batch_mod
+
+        monkeypatch.setattr(batch_mod, "PDFRetriever", lambda _c: pdf_instance)
+
+        ft_instance = MagicMock()
+        ft_instance.__aenter__ = AsyncMock(return_value=ft_instance)
+        ft_instance.__aexit__ = AsyncMock(return_value=None)
+        ft_instance.retrieve = AsyncMock(return_value=None)
+        import opencite.fulltext as ft_mod
+
+        monkeypatch.setattr(ft_mod, "FullTextRetriever", lambda _c: ft_instance)
+
+        pre_instance = MagicMock()
+        pre_instance.__aenter__ = AsyncMock(return_value=pre_instance)
+        pre_instance.__aexit__ = AsyncMock(return_value=None)
+        out_md = tmp_path / "papers" / "markdown" / "preprint.md"
+        pre_instance.retrieve_for_identifier = AsyncMock(return_value=out_md)
+        import opencite.preprint_fulltext as pre_mod
+
+        monkeypatch.setattr(
+            pre_mod, "PreprintFullTextRetriever", lambda _c: pre_instance
+        )
+
+        result = await batch_download(
+            ids=["10.48550/arXiv.1706.03762"],
+            config=Config(),
+            output_dir=str(tmp_path / "papers"),
+            convert=True,
+        )
+
+        assert result.fulltext_retrieved == 1
+        assert result.converted == 1
+        pdf_instance.download.assert_not_called()
+        pre_instance.retrieve_for_identifier.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_preprint_html_skips_preprint_tier(self, tmp_path, monkeypatch):
+        """`prefer_preprint_html=False` must not even instantiate the retriever."""
+        pdf_instance = MagicMock()
+        pdf_instance.__aenter__ = AsyncMock(return_value=pdf_instance)
+        pdf_instance.__aexit__ = AsyncMock(return_value=None)
+        pdf_instance.download = AsyncMock(return_value=None)
+        import opencite.batch as batch_mod
+
+        monkeypatch.setattr(batch_mod, "PDFRetriever", lambda _c: pdf_instance)
+
+        ft_instance = MagicMock()
+        ft_instance.__aenter__ = AsyncMock(return_value=ft_instance)
+        ft_instance.__aexit__ = AsyncMock(return_value=None)
+        ft_instance.retrieve = AsyncMock(return_value=None)
+        import opencite.fulltext as ft_mod
+
+        monkeypatch.setattr(ft_mod, "FullTextRetriever", lambda _c: ft_instance)
+
+        pre_called = MagicMock()
+        import opencite.preprint_fulltext as pre_mod
+
+        monkeypatch.setattr(pre_mod, "PreprintFullTextRetriever", pre_called)
+
+        await batch_download(
+            ids=["10.48550/arXiv.1706.03762"],
+            config=Config(),
+            output_dir=str(tmp_path / "papers"),
+            convert=True,
+            prefer_preprint_html=False,
+        )
+
+        pre_called.assert_not_called()
+        pdf_instance.download.assert_called_once()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -155,6 +155,29 @@ class TestCLIArgParsing:
         assert args.output == "/tmp/papers"
         assert args.convert is True
         assert args.converter == "mistral"
+        # Default: preprint HTML route is enabled.
+        assert args.no_preprint_html is False
+
+    def test_pdf_no_preprint_html_flag(self):
+        from opencite.cli import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(
+            ["pdf", "10.48550/arXiv.1706.03762", "--convert", "--no-preprint-html"]
+        )
+        assert args.no_preprint_html is True
+
+    def test_batch_fetch_no_preprint_html_flag(self):
+        from opencite.cli import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(
+            ["batch-fetch", "ids.txt", "--convert", "--no-preprint-html"]
+        )
+        assert args.no_preprint_html is True
+        # And not set on the default invocation.
+        args2 = parser.parse_args(["batch-fetch", "ids.txt", "--convert"])
+        assert args2.no_preprint_html is False
 
     def test_convert_parser(self):
         from opencite.cli import create_parser

--- a/tests/test_clients/test_arxiv.py
+++ b/tests/test_clients/test_arxiv.py
@@ -177,3 +177,74 @@ class TestArXivLookupDoi:
             paper = await client.lookup_doi("10.48550/ARXIV.1706.03762")
         assert paper is not None
         assert paper.ids.arxiv_id == "1706.03762"
+
+
+class TestArXivFulltext:
+    """Tests for the ar5iv HTML5 full-text route."""
+
+    def _paper_with_arxiv_id(self):
+        from opencite.models import IDSet, Paper
+
+        return Paper(title="Attention", ids=IDSet(arxiv_id="1706.03762"))
+
+    def _paper_with_arxiv_doi(self):
+        from opencite.models import IDSet, Paper
+
+        return Paper(title="Attention", ids=IDSet(doi="10.48550/arXiv.1706.03762"))
+
+    def test_fulltext_route_html_when_arxiv_id_present(self):
+        from opencite.clients.preprint_base import FulltextRoute
+
+        client = ArXivClient(Config())
+        assert client.fulltext_route(self._paper_with_arxiv_id()) == FulltextRoute.HTML
+
+    def test_fulltext_route_html_for_arxiv_doi(self):
+        from opencite.clients.preprint_base import FulltextRoute
+
+        client = ArXivClient(Config())
+        assert client.fulltext_route(self._paper_with_arxiv_doi()) == FulltextRoute.HTML
+
+    def test_fulltext_route_none_when_no_arxiv_signal(self):
+        from opencite.clients.preprint_base import FulltextRoute
+        from opencite.models import IDSet, Paper
+
+        client = ArXivClient(Config())
+        paper = Paper(title="Random", ids=IDSet(doi="10.1038/nature12373"))
+        assert client.fulltext_route(paper) == FulltextRoute.NONE
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_fetch_fulltext_uses_ar5iv(self):
+        respx.get("https://ar5iv.labs.arxiv.org/html/1706.03762").mock(
+            return_value=httpx.Response(
+                200,
+                text="<html><body><h1>Attention Is All You Need</h1>"
+                "<p>The dominant model.</p></body></html>",
+            )
+        )
+        async with ArXivClient(Config()) as client:
+            md = await client.fetch_fulltext(self._paper_with_arxiv_id())
+        assert md is not None
+        assert "Attention" in md
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_fetch_fulltext_404_returns_none(self):
+        respx.get("https://ar5iv.labs.arxiv.org/html/9999.99999").mock(
+            return_value=httpx.Response(404)
+        )
+        from opencite.models import IDSet, Paper
+
+        async with ArXivClient(Config()) as client:
+            md = await client.fetch_fulltext(
+                Paper(title="Missing", ids=IDSet(arxiv_id="9999.99999"))
+            )
+        assert md is None
+
+    @pytest.mark.asyncio
+    async def test_fetch_fulltext_no_arxiv_signal_returns_none(self):
+        from opencite.models import IDSet, Paper
+
+        async with ArXivClient(Config()) as client:
+            md = await client.fetch_fulltext(Paper(title="Random", ids=IDSet()))
+        assert md is None

--- a/tests/test_clients/test_biorxiv_like.py
+++ b/tests/test_clients/test_biorxiv_like.py
@@ -124,3 +124,85 @@ class TestBiorxivLikeLookupDoi:
         assert "medrxiv" in paper.data_sources
         assert medrxiv_route.called
         assert not biorxiv_route.called
+
+
+class TestBiorxivLikeFulltext:
+    """Tests for `.full` HTML full-text route on bioRxiv and medRxiv."""
+
+    def test_fulltext_route_html_for_biorxiv_doi(self, _config: Config):
+        from opencite.clients.preprint_base import FulltextRoute
+        from opencite.models import IDSet, Paper
+
+        client = BioRxivClient(_config)
+        paper = Paper(title="A", ids=IDSet(doi="10.1101/2024.01.01.000001"))
+        assert client.fulltext_route(paper) == FulltextRoute.HTML
+
+    def test_fulltext_route_none_without_biorxiv_doi(self, _config: Config):
+        from opencite.clients.preprint_base import FulltextRoute
+        from opencite.models import IDSet, Paper
+
+        client = BioRxivClient(_config)
+        paper = Paper(title="A", ids=IDSet(doi="10.1038/nature12373"))
+        assert client.fulltext_route(paper) == FulltextRoute.NONE
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_fetch_fulltext_biorxiv_full_html(self, _config: Config):
+        from opencite.models import IDSet, Paper
+
+        doi = "10.1101/2024.01.01.000001"
+        respx.get(f"https://www.biorxiv.org/content/{doi}.full").mock(
+            return_value=httpx.Response(
+                200,
+                text=(
+                    "<html><body><h1>A bioRxiv paper</h1><p>Methods.</p></body></html>"
+                ),
+            )
+        )
+        async with BioRxivClient(_config) as client:
+            md = await client.fetch_fulltext(Paper(title="x", ids=IDSet(doi=doi)))
+        assert md is not None
+        assert "bioRxiv paper" in md
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_fetch_fulltext_medrxiv_uses_medrxiv_domain(self, _config: Config):
+        from opencite.models import IDSet, Paper
+
+        doi = "10.1101/2024.05.01.000999"
+        biorxiv_route = respx.get(f"https://www.biorxiv.org/content/{doi}.full").mock(
+            return_value=httpx.Response(404)
+        )
+        medrxiv_route = respx.get(f"https://www.medrxiv.org/content/{doi}.full").mock(
+            return_value=httpx.Response(
+                200,
+                text="<html><body><h1>A medRxiv paper</h1></body></html>",
+            )
+        )
+        async with MedRxivClient(_config) as client:
+            md = await client.fetch_fulltext(Paper(title="x", ids=IDSet(doi=doi)))
+        assert md is not None
+        assert "medRxiv paper" in md
+        assert medrxiv_route.called
+        assert not biorxiv_route.called
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_fetch_fulltext_404_returns_none(self, _config: Config):
+        from opencite.models import IDSet, Paper
+
+        doi = "10.1101/withdrawn"
+        respx.get(f"https://www.biorxiv.org/content/{doi}.full").mock(
+            return_value=httpx.Response(404)
+        )
+        async with BioRxivClient(_config) as client:
+            md = await client.fetch_fulltext(Paper(title="x", ids=IDSet(doi=doi)))
+        assert md is None
+
+    @pytest.mark.asyncio
+    async def test_fetch_fulltext_no_doi_returns_none(self, _config: Config):
+        from opencite.models import IDSet, Paper
+
+        async with BioRxivClient(_config) as client:
+            md = await client.fetch_fulltext(Paper(title="x", ids=IDSet()))
+        assert md is None

--- a/tests/test_clients/test_preprint_base.py
+++ b/tests/test_clients/test_preprint_base.py
@@ -47,20 +47,27 @@ class TestPreprintClientABC:
         "cls",
         [ArXivClient, BioRxivClient, MedRxivClient],
     )
-    def test_default_fulltext_route_is_none(self, cls):
-        """Phase 1 ships no preprint-native full-text routes; Phase 2 adds them."""
+    def test_fulltext_route_none_when_no_preprint_signal(self, cls):
+        """Without an arXiv ID or a 10.1101/* DOI, no preprint route applies."""
+        from opencite.models import IDSet, Paper
+
         client = cls(Config())
-        # ``Paper`` argument is unused in the default impl; pass None.
-        assert client.fulltext_route(None) == FulltextRoute.NONE  # type: ignore[arg-type]
+        empty_paper = Paper(title="x", ids=IDSet(doi="10.1038/nature12373"))
+        assert client.fulltext_route(empty_paper) == FulltextRoute.NONE
 
     @pytest.mark.parametrize(
         "cls",
         [ArXivClient, BioRxivClient, MedRxivClient],
     )
     @pytest.mark.asyncio
-    async def test_default_fetch_fulltext_returns_none(self, cls):
+    async def test_fetch_fulltext_none_when_no_preprint_signal(self, cls):
+        """`fetch_fulltext` short-circuits to None before opening any session."""
+        from opencite.models import IDSet, Paper
+
         client = cls(Config())
-        assert await client.fetch_fulltext(None) is None  # type: ignore[arg-type]
+        empty_paper = Paper(title="x", ids=IDSet(doi="10.1038/nature12373"))
+        # No `async with`: short-circuit must fire before any network use.
+        assert await client.fetch_fulltext(empty_paper) is None
 
 
 class TestPreprintClientSubclassEnforcement:

--- a/tests/test_clients/test_preprint_base.py
+++ b/tests/test_clients/test_preprint_base.py
@@ -7,7 +7,11 @@ import pytest
 from opencite.clients.arxiv import ArXivClient
 from opencite.clients.biorxiv import BioRxivClient
 from opencite.clients.medrxiv import MedRxivClient
-from opencite.clients.preprint_base import FulltextRoute, PreprintClient
+from opencite.clients.preprint_base import (
+    FulltextRoute,
+    PreprintClient,
+    html_to_markdown,
+)
 from opencite.config import Config
 
 
@@ -93,3 +97,31 @@ class TestPreprintClientSubclassEnforcement:
 
             class BadConcreteServerClient(_BiorxivLikePreprintClient):  # type: ignore[misc]
                 name = "bad-without-server"
+
+
+class TestHtmlToMarkdown:
+    """Round-trip and edge-case behavior of the shared HTML helper."""
+
+    def test_basic_html_converts_headings_and_paragraphs(self):
+        html = "<html><body><h1>Title</h1><p>Body text.</p></body></html>"
+        md = html_to_markdown(html)
+        assert md is not None
+        assert "Title" in md
+        assert "Body text" in md
+
+    def test_empty_input_returns_string(self):
+        # markitdown returns an empty body for empty input rather than raising.
+        # Either an empty string or None is acceptable behavior; the helper
+        # must not raise.
+        result = html_to_markdown("")
+        assert result == "" or result is None
+
+    def test_malformed_html_still_returns_text(self):
+        """markitdown is forgiving; broken tags should still yield text."""
+        md = html_to_markdown("<h1>A<unclosed><p>B</body>")
+        assert md is not None
+        assert "A" in md and "B" in md
+
+    def test_context_does_not_change_output(self):
+        html = "<p>Hello.</p>"
+        assert html_to_markdown(html) == html_to_markdown(html, context="x:y")

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -375,3 +375,103 @@ class TestUnpaywallIntegration:
         urls = await retriever._collect_urls(paper, "10.1234/test")
         # Should still have DOI URL at minimum
         assert "https://doi.org/10.1234/test" in urls
+
+
+class TestRetrieveAsMarkdownChainOrder:
+    """`PDFRetriever.retrieve_as_markdown` chains PMC -> preprint HTML -> PDF.
+
+    Stub the two retrievers to assert ordering and the early-exit semantics:
+    a successful tier short-circuits the rest of the chain.
+    """
+
+    @staticmethod
+    def _stub_paper() -> Paper:
+        return Paper(title="x", ids=IDSet(doi="10.48550/arXiv.1706.03762"))
+
+    @pytest.mark.asyncio
+    async def test_pmc_wins_over_preprint(self, tmp_path, monkeypatch):
+        retriever = _make_retriever()
+        retriever._quick_lookup = AsyncMock(return_value=self._stub_paper())
+
+        pmc_path = tmp_path / "pmc.md"
+        pmc_path.write_text("from pmc")
+
+        ft_instance = MagicMock()
+        ft_instance.__aenter__ = AsyncMock(return_value=ft_instance)
+        ft_instance.__aexit__ = AsyncMock(return_value=None)
+        ft_instance.retrieve = AsyncMock(return_value=pmc_path)
+
+        pre_called = MagicMock()
+
+        import opencite.fulltext as ft_mod
+        import opencite.preprint_fulltext as pre_mod
+
+        monkeypatch.setattr(ft_mod, "FullTextRetriever", lambda _c: ft_instance)
+        monkeypatch.setattr(pre_mod, "PreprintFullTextRetriever", pre_called)
+
+        result = await retriever.retrieve_as_markdown(
+            "10.48550/arXiv.1706.03762", output_dir=str(tmp_path)
+        )
+        assert result == pmc_path
+        pre_called.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_preprint_wins_over_pdf_when_pmc_misses(self, tmp_path, monkeypatch):
+        retriever = _make_retriever()
+        retriever._quick_lookup = AsyncMock(return_value=self._stub_paper())
+
+        ft_instance = MagicMock()
+        ft_instance.__aenter__ = AsyncMock(return_value=ft_instance)
+        ft_instance.__aexit__ = AsyncMock(return_value=None)
+        ft_instance.retrieve = AsyncMock(return_value=None)  # PMC miss
+
+        pre_path = tmp_path / "preprint.md"
+        pre_path.write_text("from preprint")
+        pre_instance = MagicMock()
+        pre_instance.__aenter__ = AsyncMock(return_value=pre_instance)
+        pre_instance.__aexit__ = AsyncMock(return_value=None)
+        pre_instance.retrieve = AsyncMock(return_value=pre_path)
+
+        retriever.download = AsyncMock()
+
+        import opencite.fulltext as ft_mod
+        import opencite.preprint_fulltext as pre_mod
+
+        monkeypatch.setattr(ft_mod, "FullTextRetriever", lambda _c: ft_instance)
+        monkeypatch.setattr(
+            pre_mod, "PreprintFullTextRetriever", lambda _c: pre_instance
+        )
+
+        result = await retriever.retrieve_as_markdown(
+            "10.48550/arXiv.1706.03762", output_dir=str(tmp_path)
+        )
+        assert result == pre_path
+        retriever.download.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_preprint_html_skips_preprint_tier(self, tmp_path, monkeypatch):
+        """`prefer_preprint_html=False` must skip the preprint tier entirely."""
+        retriever = _make_retriever()
+        retriever._quick_lookup = AsyncMock(return_value=self._stub_paper())
+
+        ft_instance = MagicMock()
+        ft_instance.__aenter__ = AsyncMock(return_value=ft_instance)
+        ft_instance.__aexit__ = AsyncMock(return_value=None)
+        ft_instance.retrieve = AsyncMock(return_value=None)  # PMC miss
+
+        pre_called = MagicMock()
+        retriever.download = AsyncMock(return_value=None)  # PDF miss too
+
+        import opencite.fulltext as ft_mod
+        import opencite.preprint_fulltext as pre_mod
+
+        monkeypatch.setattr(ft_mod, "FullTextRetriever", lambda _c: ft_instance)
+        monkeypatch.setattr(pre_mod, "PreprintFullTextRetriever", pre_called)
+
+        await retriever.retrieve_as_markdown(
+            "10.48550/arXiv.1706.03762",
+            output_dir=str(tmp_path),
+            prefer_preprint_html=False,
+        )
+        pre_called.assert_not_called()
+        retriever.download.assert_called_once()

--- a/tests/test_preprint_fulltext.py
+++ b/tests/test_preprint_fulltext.py
@@ -1,0 +1,185 @@
+"""Tests for the PreprintFullTextRetriever dispatch + writer.
+
+The retriever picks the right `PreprintClient` for a paper by data_sources
+attribution first, then DOI prefix. These tests stub the clients so the
+dispatch logic is exercised without hitting any network.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import pytest
+
+from opencite.clients.preprint_base import FulltextRoute, PreprintClient
+from opencite.config import Config
+from opencite.models import IDSet, Paper
+from opencite.preprint_fulltext import PreprintFullTextRetriever
+
+
+class _FakePreprintClient(PreprintClient):
+    """Minimal in-memory preprint client used to validate dispatch.
+
+    Records every call to ``fetch_fulltext`` so tests can assert which client
+    served a given paper. Returns a deterministic markdown body keyed on the
+    client name and the paper DOI / arXiv ID.
+    """
+
+    def __init__(self, config: Config, name_value: str) -> None:
+        # Construct via a public-facing arXiv-style base URL; we never hit
+        # the network in these tests, so the URL is purely cosmetic.
+        super().__init__(
+            config=config,
+            base_url="https://example.invalid",
+            rate_limit=1000.0,
+            burst=10,
+        )
+        # Override the ClassVar at instance level for each fake instance.
+        self.name = name_value  # type: ignore[misc]
+        self.fetch_calls: list[Paper] = []
+
+    def _default_headers(self) -> dict[str, str]:
+        return {}
+
+    async def search(self, query: str, max_results: int = 20, **kwargs):  # noqa: ARG002
+        return []
+
+    async def lookup_doi(self, doi: str):  # noqa: ARG002
+        return None
+
+    def fulltext_route(self, paper: Paper) -> FulltextRoute:  # noqa: ARG002
+        return FulltextRoute.HTML
+
+    async def fetch_fulltext(self, paper: Paper) -> str | None:
+        self.fetch_calls.append(paper)
+        ident = paper.doi or paper.ids.arxiv_id or "unknown"
+        return f"# {self.name}: {ident}\n\nFake markdown."
+
+
+# Subclasses with proper ClassVar names so __init_subclass__ accepts them.
+class FakeArxiv(_FakePreprintClient):
+    name: ClassVar[str] = "arxiv"
+
+    def __init__(self, config: Config) -> None:
+        super().__init__(config, "arxiv")
+
+
+class FakeBiorxiv(_FakePreprintClient):
+    name: ClassVar[str] = "biorxiv"
+
+    def __init__(self, config: Config) -> None:
+        super().__init__(config, "biorxiv")
+
+
+class FakeMedrxiv(_FakePreprintClient):
+    name: ClassVar[str] = "medrxiv"
+
+    def __init__(self, config: Config) -> None:
+        super().__init__(config, "medrxiv")
+
+
+@pytest.fixture
+def _config() -> Config:
+    return Config()
+
+
+@pytest.fixture
+async def retriever(_config: Config):
+    fakes = [FakeArxiv(_config), FakeBiorxiv(_config), FakeMedrxiv(_config)]
+    async with PreprintFullTextRetriever(_config, clients=fakes) as r:
+        yield r, fakes
+
+
+class TestDispatch:
+    @pytest.mark.asyncio
+    async def test_data_source_attribution_picks_client(self, retriever, tmp_path):
+        r, fakes = retriever
+        paper = Paper(
+            title="Some preprint",
+            ids=IDSet(doi="10.1234/foo"),  # not a known prefix
+            data_sources={"medrxiv"},
+        )
+        path = await r.retrieve(paper, output_dir=tmp_path, identifier="10.1234/foo")
+        assert path is not None
+        # FakeMedrxiv (index 2) was called; others were not.
+        assert len(fakes[2].fetch_calls) == 1
+        assert fakes[0].fetch_calls == []
+        assert fakes[1].fetch_calls == []
+
+    @pytest.mark.asyncio
+    async def test_arxiv_doi_prefix_routes_to_arxiv(self, retriever, tmp_path):
+        r, fakes = retriever
+        paper = Paper(
+            title="ArXiv paper",
+            ids=IDSet(doi="10.48550/arXiv.1706.03762"),
+        )
+        path = await r.retrieve(paper, output_dir=tmp_path, identifier="arxiv-doi")
+        assert path is not None
+        assert len(fakes[0].fetch_calls) == 1
+        assert fakes[1].fetch_calls == []
+
+    @pytest.mark.asyncio
+    async def test_biorxiv_prefix_routes_to_biorxiv(self, retriever, tmp_path):
+        r, fakes = retriever
+        paper = Paper(
+            title="bioRxiv paper",
+            ids=IDSet(doi="10.1101/2024.09.12.612645"),
+        )
+        path = await r.retrieve(paper, output_dir=tmp_path, identifier="biorxiv-doi")
+        assert path is not None
+        # bioRxiv preferred over medRxiv when DOI prefix alone is the signal.
+        assert len(fakes[1].fetch_calls) == 1
+        assert fakes[2].fetch_calls == []
+
+    @pytest.mark.asyncio
+    async def test_unknown_doi_returns_none(self, retriever, tmp_path):
+        r, _ = retriever
+        paper = Paper(
+            title="Random paper",
+            ids=IDSet(doi="10.1038/nature12373"),
+        )
+        path = await r.retrieve(paper, output_dir=tmp_path, identifier="random")
+        assert path is None
+
+    @pytest.mark.asyncio
+    async def test_route_none_returns_none(self, _config: Config, tmp_path):
+        """A client whose route is NONE must not be invoked for fetch."""
+
+        class FakeNoneRoute(_FakePreprintClient):
+            name: ClassVar[str] = "biorxiv"
+
+            def __init__(self, config: Config) -> None:
+                super().__init__(config, "biorxiv")
+
+            def fulltext_route(self, paper: Paper) -> FulltextRoute:  # noqa: ARG002
+                return FulltextRoute.NONE
+
+        fake = FakeNoneRoute(_config)
+        async with PreprintFullTextRetriever(_config, clients=[fake]) as r:
+            paper = Paper(
+                title="bioRxiv paper",
+                ids=IDSet(doi="10.1101/2024.09.12.612645"),
+            )
+            path = await r.retrieve(paper, output_dir=tmp_path, identifier="x")
+        assert path is None
+        # fetch_fulltext was never called because the route was NONE.
+        assert fake.fetch_calls == []
+
+
+class TestWrite:
+    @pytest.mark.asyncio
+    async def test_writes_markdown_to_output_dir(self, retriever, tmp_path):
+        r, _ = retriever
+        paper = Paper(
+            title="Attention Is All You Need",
+            ids=IDSet(doi="10.48550/arXiv.1706.03762"),
+        )
+        path = await r.retrieve(
+            paper,
+            output_dir=tmp_path,
+            identifier="attention",
+        )
+        assert path is not None
+        assert path.exists()
+        content = path.read_text(encoding="utf-8")
+        assert "arxiv: 10.48550/arXiv.1706.03762" in content

--- a/tests/test_preprint_fulltext.py
+++ b/tests/test_preprint_fulltext.py
@@ -183,3 +183,103 @@ class TestWrite:
         assert path.exists()
         content = path.read_text(encoding="utf-8")
         assert "arxiv: 10.48550/arXiv.1706.03762" in content
+
+
+class TestPickClientPriority:
+    """``data_sources`` attribution must win over DOI prefix."""
+
+    @pytest.mark.asyncio
+    async def test_data_sources_overrides_doi_prefix(self, retriever):
+        r, fakes = retriever
+        # Paper claims arXiv attribution but carries a 10.1101/* DOI: the
+        # `data_sources` signal must win and route to FakeArxiv, not to
+        # FakeBiorxiv (which would match by DOI prefix alone).
+        paper = Paper(
+            title="Cross-deposited preprint",
+            ids=IDSet(doi="10.1101/2024.01.01.000001"),
+            data_sources={"arxiv"},
+        )
+        client = r._pick_client(paper)
+        assert client is fakes[0]
+        assert client.name == "arxiv"
+
+
+class TestRetrieveForIdentifier:
+    """``retrieve_for_identifier`` must accept arXiv IDs, not just DOIs."""
+
+    @pytest.mark.asyncio
+    async def test_bare_arxiv_id_routes_to_arxiv(self, retriever, tmp_path):
+        r, fakes = retriever
+        # ``parse_identifier`` recognises ``2106.15928`` as an arXiv ID.
+        path = await r.retrieve_for_identifier("2106.15928", output_dir=tmp_path)
+        assert path is not None
+        assert len(fakes[0].fetch_calls) == 1
+        # The dispatched paper carried the arXiv ID, not a DOI.
+        assert fakes[0].fetch_calls[0].ids.arxiv_id == "2106.15928"
+
+    @pytest.mark.asyncio
+    async def test_arxiv_url_routes_to_arxiv(self, retriever, tmp_path):
+        r, fakes = retriever
+        path = await r.retrieve_for_identifier("arxiv:2106.15928", output_dir=tmp_path)
+        assert path is not None
+        assert len(fakes[0].fetch_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_biorxiv_doi_routes_to_biorxiv(self, retriever, tmp_path):
+        r, fakes = retriever
+        path = await r.retrieve_for_identifier(
+            "10.1101/2024.09.12.612645", output_dir=tmp_path
+        )
+        assert path is not None
+        assert len(fakes[1].fetch_calls) == 1
+
+
+class TestPartialEnterRollback:
+    """A failure mid-init must close already-entered clients."""
+
+    @pytest.mark.asyncio
+    async def test_failed_client_init_closes_predecessors(self, _config: Config):
+        """If client #2 fails to enter, client #1 must be closed."""
+        from opencite.clients.preprint_base import PreprintClient
+
+        class GoodClient(_FakePreprintClient):
+            name: ClassVar[str] = "arxiv"
+
+            def __init__(self, config: Config) -> None:
+                super().__init__(config, "arxiv")
+                self.exited = False
+
+            async def __aexit__(self, *args):
+                self.exited = True
+                await super().__aexit__(*args)
+
+        class BadClient(PreprintClient):
+            name: ClassVar[str] = "biorxiv"
+
+            def __init__(self, config: Config) -> None:
+                super().__init__(
+                    config=config,
+                    base_url="https://example.invalid",
+                    rate_limit=1000.0,
+                    burst=10,
+                )
+
+            def _default_headers(self) -> dict[str, str]:
+                return {}
+
+            async def __aenter__(self):
+                raise RuntimeError("synthetic init failure")
+
+            async def search(self, query, max_results=20, **kwargs):  # noqa: ARG002
+                return []
+
+            async def lookup_doi(self, doi):  # noqa: ARG002
+                return None
+
+        good = GoodClient(_config)
+        bad = BadClient(_config)
+        with pytest.raises(RuntimeError, match="synthetic init failure"):
+            async with PreprintFullTextRetriever(_config, clients=[good, bad]):
+                pass
+        # The good client must have been closed even though enter failed.
+        assert good.exited is True


### PR DESCRIPTION
## Summary
- Fills in `PreprintClient.fulltext_route` and `fetch_fulltext` for arXiv (ar5iv HTML5) and bioRxiv/medRxiv (`.full` HTML).
- New `PreprintFullTextRetriever` (in `src/opencite/preprint_fulltext.py`) picks the right preprint client by `data_sources` attribution first, then DOI prefix.
- `pdf.retrieve_as_markdown` and `batch.py` now try preprint HTML between PMC full-text and the PDF download path; OA preprints convert directly from HTML to markdown.
- New `--no-preprint-html` flag on `opencite pdf` and `opencite batch-fetch` for fine-grained opt-out, separate from `--no-fulltext` (PMC).
- HTML to markdown conversion uses the existing `markitdown` dep (also used by the PDF pipeline) via its stream API for shape consistency.

Closes #25
Part of epic #23

## Test plan
- [x] `uv run ruff check src/ tests/` clean
- [x] `uv run ruff format --check src/ tests/` clean
- [x] `uv run pytest` -- 639 tests pass (was 622; +17 new)
- [ ] Manual: `uv run opencite pdf 10.48550/arXiv.1706.03762 --convert -o attention.md` -- ar5iv route, no PDF download
- [ ] Manual: `uv run opencite pdf 10.1101/2024.09.12.612645 --convert -o single-cell.md` -- bioRxiv `.full` route
- [ ] Manual: same DOIs with `--no-preprint-html` -- falls back to PDF + markitdown