### PR TITLE
Per-source shared rate limiter + disabled_sources opt-out (#34)

### DIFF
--- a/src/opencite/citations.py
+++ b/src/opencite/citations.py
@@ -9,7 +9,8 @@ from typing import TYPE_CHECKING
 from opencite.clients.openalex import OpenAlexClient
 from opencite.clients.semantic_scholar import SemanticScholarClient
 from opencite.dedup import deduplicate
-from opencite.models import CitationResult, IDType, Paper, parse_identifier
+from opencite.models import CitationResult, IDSet, IDType, Paper, parse_identifier
+from opencite.sources import is_source_enabled
 
 if TYPE_CHECKING:
     from opencite.config import Config
@@ -19,6 +20,11 @@ logger = logging.getLogger(__name__)
 
 class CitationExplorer:
     """Explores citation graphs and finds canonical papers.
+
+    Honors `config.disabled_sources`: a disabled source's client is never
+    constructed, so its rate budget isn't touched and its async failures
+    can't slow down the parallel gather. Disabling both `openalex` and
+    `s2` leaves nothing to query and raises at construction time.
 
     Usage::
 
@@ -30,17 +36,34 @@ class CitationExplorer:
 
     def __init__(self, config: Config):
         self.config = config
-        self._openalex = OpenAlexClient(config)
-        self._s2 = SemanticScholarClient(config)
+        self._openalex: OpenAlexClient | None = (
+            OpenAlexClient(config)
+            if is_source_enabled("openalex", config.disabled_sources)
+            else None
+        )
+        self._s2: SemanticScholarClient | None = (
+            SemanticScholarClient(config)
+            if is_source_enabled("s2", config.disabled_sources)
+            else None
+        )
+        if self._openalex is None and self._s2 is None:
+            raise ValueError(
+                "CitationExplorer needs at least one of `openalex` or `s2`; "
+                "both are listed in config.disabled_sources."
+            )
 
     async def __aenter__(self) -> CitationExplorer:
-        await self._openalex.__aenter__()
-        await self._s2.__aenter__()
+        if self._openalex is not None:
+            await self._openalex.__aenter__()
+        if self._s2 is not None:
+            await self._s2.__aenter__()
         return self
 
     async def __aexit__(self, *args: object) -> None:
-        await self._openalex.__aexit__()
-        await self._s2.__aexit__()
+        if self._openalex is not None:
+            await self._openalex.__aexit__()
+        if self._s2 is not None:
+            await self._s2.__aexit__()
 
     async def citing_papers(
         self,
@@ -64,7 +87,7 @@ class CitationExplorer:
         # Get citing papers from available sources
         tasks: list[asyncio.Task[list[Paper]]] = []
 
-        if seed.ids.openalex_id:
+        if self._openalex is not None and seed.ids.openalex_id:
             tasks.append(
                 asyncio.create_task(
                     self._openalex.citing_papers(
@@ -72,18 +95,23 @@ class CitationExplorer:
                     )
                 )
             )
-        if seed.ids.s2_id:
-            tasks.append(
-                asyncio.create_task(
-                    self._s2.citing_papers(seed.ids.s2_id, max_results=max_results)
+        if self._s2 is not None:
+            if seed.ids.s2_id:
+                tasks.append(
+                    asyncio.create_task(
+                        self._s2.citing_papers(
+                            seed.ids.s2_id, max_results=max_results
+                        )
+                    )
                 )
-            )
-        elif seed.doi:
-            tasks.append(
-                asyncio.create_task(
-                    self._s2.citing_papers(f"DOI:{seed.doi}", max_results=max_results)
+            elif seed.doi:
+                tasks.append(
+                    asyncio.create_task(
+                        self._s2.citing_papers(
+                            f"DOI:{seed.doi}", max_results=max_results
+                        )
+                    )
                 )
-            )
 
         all_papers = await _gather_papers(tasks)
 
@@ -120,7 +148,7 @@ class CitationExplorer:
 
         tasks: list[asyncio.Task[list[Paper]]] = []
 
-        if seed.ids.openalex_id:
+        if self._openalex is not None and seed.ids.openalex_id:
             tasks.append(
                 asyncio.create_task(
                     self._openalex.references(
@@ -128,18 +156,21 @@ class CitationExplorer:
                     )
                 )
             )
-        if seed.ids.s2_id:
-            tasks.append(
-                asyncio.create_task(
-                    self._s2.references(seed.ids.s2_id, max_results=max_results)
+        if self._s2 is not None:
+            if seed.ids.s2_id:
+                tasks.append(
+                    asyncio.create_task(
+                        self._s2.references(seed.ids.s2_id, max_results=max_results)
+                    )
                 )
-            )
-        elif seed.doi:
-            tasks.append(
-                asyncio.create_task(
-                    self._s2.references(f"DOI:{seed.doi}", max_results=max_results)
+            elif seed.doi:
+                tasks.append(
+                    asyncio.create_task(
+                        self._s2.references(
+                            f"DOI:{seed.doi}", max_results=max_results
+                        )
+                    )
                 )
-            )
 
         all_papers = await _gather_papers(tasks)
         unique = deduplicate(all_papers)
@@ -161,8 +192,15 @@ class CitationExplorer:
     ) -> list[Paper]:
         """Find the most-cited papers in a field.
 
-        Uses OpenAlex sorted by citation count descending.
+        Uses OpenAlex sorted by citation count descending. Raises
+        `RuntimeError` if `openalex` is disabled, since no other source
+        in the explorer can substitute.
         """
+        if self._openalex is None:
+            raise RuntimeError(
+                "canonical_papers requires `openalex`, which is disabled in "
+                "config.disabled_sources."
+            )
         papers = await self._openalex.canonical_search(
             query,
             max_results=max_results,
@@ -172,47 +210,49 @@ class CitationExplorer:
         return papers
 
     async def _lookup_seed(self, id_type: IDType, id_value: str) -> Paper | None:
-        """Look up the seed paper to get IDs for citation queries."""
-        if id_type == IDType.DOI:
-            # Try S2 first for fast lookup + S2 ID
-            paper = await self._s2.lookup(f"DOI:{id_value}")
-            if paper:
-                # Also get OpenAlex ID
-                oa_paper = await self._openalex.lookup_doi(id_value)
-                if oa_paper:
-                    from opencite.dedup import merge_papers
+        """Look up the seed paper to get IDs for citation queries.
 
-                    paper = merge_papers(paper, oa_paper)
+        When a source is disabled, fall back to whichever client is still
+        constructed; if neither can serve the ID type, return None.
+        """
+        from opencite.dedup import merge_papers
+
+        s2_lookup = self._s2.lookup if self._s2 is not None else None
+        openalex_doi = self._openalex.lookup_doi if self._openalex is not None else None
+
+        if id_type == IDType.DOI:
+            paper = await s2_lookup(f"DOI:{id_value}") if s2_lookup else None
+            if paper:
+                if openalex_doi:
+                    oa_paper = await openalex_doi(id_value)
+                    if oa_paper:
+                        paper = merge_papers(paper, oa_paper)
                 return paper
-            return await self._openalex.lookup_doi(id_value)
+            return await openalex_doi(id_value) if openalex_doi else None
 
         if id_type == IDType.PMID:
-            paper = await self._s2.lookup(f"PMID:{id_value}")
-            if paper and paper.doi:
-                oa_paper = await self._openalex.lookup_doi(paper.doi)
+            paper = await s2_lookup(f"PMID:{id_value}") if s2_lookup else None
+            if paper and paper.doi and openalex_doi:
+                oa_paper = await openalex_doi(paper.doi)
                 if oa_paper:
-                    from opencite.dedup import merge_papers
-
                     paper = merge_papers(paper, oa_paper)
             return paper
 
         if id_type == IDType.ARXIV:
-            return await self._s2.lookup(f"ARXIV:{id_value}")
+            return await s2_lookup(f"ARXIV:{id_value}") if s2_lookup else None
 
         if id_type == IDType.S2:
-            return await self._s2.lookup(id_value)
+            return await s2_lookup(id_value) if s2_lookup else None
 
         if id_type == IDType.OPENALEX:
-            return await self._openalex.lookup_doi(id_value)
+            return await openalex_doi(id_value) if openalex_doi else None
 
         return None
 
 
-def _make_ids(id_type: IDType, id_value: str) -> object:
+def _make_ids(id_type: IDType, id_value: str) -> IDSet:
     """Create an IDSet with the given ID type populated."""
-    from opencite.models import IDSet
-
-    kwargs = {
+    field_by_type = {
         IDType.DOI: "doi",
         IDType.PMID: "pmid",
         IDType.PMCID: "pmcid",
@@ -220,7 +260,7 @@ def _make_ids(id_type: IDType, id_value: str) -> object:
         IDType.S2: "s2_id",
         IDType.ARXIV: "arxiv_id",
     }
-    field_name = kwargs.get(id_type, "doi")
+    field_name = field_by_type.get(id_type, "doi")
     return IDSet(**{field_name: id_value})
 
 

--- a/src/opencite/clients/base.py
+++ b/src/opencite/clients/base.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 import time
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import httpx
 
@@ -19,7 +20,14 @@ logger = logging.getLogger(__name__)
 
 
 class RateLimiter:
-    """Token bucket rate limiter for async operations."""
+    """Token bucket rate limiter for async operations.
+
+    The token state (rate, tokens, refill clock) is plain floats and safe
+    to share across event loops. The serializing `asyncio.Lock`, however,
+    binds to whichever event loop first acquires it; when the limiter is
+    re-used from a different loop (e.g. successive pytest-asyncio test
+    functions), the lock is transparently recreated.
+    """
 
     def __init__(self, rate: float, burst: int = 1):
         """
@@ -31,11 +39,19 @@ class RateLimiter:
         self.burst = burst
         self._tokens = float(burst)
         self._last_refill = time.monotonic()
-        self._lock = asyncio.Lock()
+        self._lock: asyncio.Lock | None = None
+        self._lock_loop_id: int | None = None
+
+    def _lock_for_loop(self) -> asyncio.Lock:
+        loop_id = id(asyncio.get_running_loop())
+        if self._lock is None or self._lock_loop_id != loop_id:
+            self._lock = asyncio.Lock()
+            self._lock_loop_id = loop_id
+        return self._lock
 
     async def acquire(self) -> None:
         """Wait until a token is available, then consume one."""
-        async with self._lock:
+        async with self._lock_for_loop():
             now = time.monotonic()
             elapsed = now - self._last_refill
             self._tokens = min(self.burst, self._tokens + elapsed * self.rate)
@@ -55,7 +71,20 @@ class BaseClient(ABC):
 
     Handles HTTP session lifecycle, rate limiting, retries,
     and error normalization.
+
+    Subclasses that should share a single token bucket across every
+    instance in the process (e.g. Semantic Scholar's ~1 req/sec budget)
+    set `shared_limiter_key` to a unique string. The first instance to
+    initialize creates the limiter at the given rate; later instances
+    reuse it regardless of who created them. Subclasses without a key
+    keep per-instance limiters, matching the previous behavior.
     """
+
+    # Per-process registry of shared rate limiters, keyed by `shared_limiter_key`.
+    # Populated lazily by `__init__`. Use `reset_shared_limiters()` for tests.
+    _shared_limiters: ClassVar[dict[str, RateLimiter]] = {}
+    _shared_limiters_lock: ClassVar[threading.Lock] = threading.Lock()
+    shared_limiter_key: ClassVar[str | None] = None
 
     def __init__(
         self,
@@ -68,10 +97,27 @@ class BaseClient(ABC):
     ):
         self.config = config
         self.base_url = base_url
-        self.rate_limiter = RateLimiter(rate_limit, burst)
+        self.rate_limiter = self._resolve_rate_limiter(rate_limit, burst)
         self.timeout = timeout or config.timeout
         self.max_retries = max_retries or config.max_retries
         self._client: httpx.AsyncClient | None = None
+
+    def _resolve_rate_limiter(self, rate_limit: float, burst: int) -> RateLimiter:
+        key = self.shared_limiter_key
+        if key is None:
+            return RateLimiter(rate_limit, burst)
+        with BaseClient._shared_limiters_lock:
+            limiter = BaseClient._shared_limiters.get(key)
+            if limiter is None:
+                limiter = RateLimiter(rate_limit, burst)
+                BaseClient._shared_limiters[key] = limiter
+            return limiter
+
+    @classmethod
+    def reset_shared_limiters(cls) -> None:
+        """Clear the shared limiter registry. Intended for tests."""
+        with BaseClient._shared_limiters_lock:
+            BaseClient._shared_limiters.clear()
 
     async def __aenter__(self) -> BaseClient:
         self._client = httpx.AsyncClient(

--- a/src/opencite/clients/id_converter.py
+++ b/src/opencite/clients/id_converter.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from opencite.clients.base import BaseClient
 from opencite.models import IDSet
@@ -22,7 +22,11 @@ class IDConverterClient(BaseClient):
 
     Converts between PMID, PMCID, DOI, and Manuscript IDs.
     Up to 200 IDs per request, but all IDs must be the same type.
+
+    Shares the NCBI eutils rate limiter with `PubMedClient`.
     """
+
+    shared_limiter_key: ClassVar[str | None] = "ncbi_eutils"
 
     def __init__(self, config: Config):
         super().__init__(

--- a/src/opencite/clients/openalex.py
+++ b/src/opencite/clients/openalex.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from opencite.clients.base import BaseClient
 from opencite.models import Author, IDSet, Paper, PDFLocation, Source
@@ -22,7 +22,12 @@ class OpenAlexClient(BaseClient):
 
     Uses httpx directly (not pyalex) for consistency with other clients
     and to integrate rate limiting through the BaseClient.
+
+    Shares a process-wide rate limiter so concurrent search and citation
+    callers don't multiply requests past the per-key OpenAlex budget.
     """
+
+    shared_limiter_key: ClassVar[str | None] = "openalex"
 
     def __init__(self, config: Config):
         super().__init__(

--- a/src/opencite/clients/pubmed.py
+++ b/src/opencite/clients/pubmed.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import re
 import xml.etree.ElementTree as ET
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from opencite.clients.base import BaseClient
 from opencite.models import Author, IDSet, Paper, Source
@@ -23,7 +23,13 @@ class PubMedClient(BaseClient):
 
     Uses esearch for keyword queries, efetch for metadata retrieval,
     and elink for citation/reference traversal.
+
+    Shares a process-wide rate limiter with `IDConverterClient` (both hit
+    NCBI eutils) so the 10 req/sec budget with an API key (3 req/sec
+    without) is honored across all callers.
     """
+
+    shared_limiter_key: ClassVar[str | None] = "ncbi_eutils"
 
     def __init__(self, config: Config):
         super().__init__(

--- a/src/opencite/clients/semantic_scholar.py
+++ b/src/opencite/clients/semantic_scholar.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from opencite.clients.base import BaseClient
 from opencite.models import Author, IDSet, Paper, PDFLocation, Source
@@ -58,7 +58,15 @@ CITATION_FIELDS = ",".join(
 
 
 class SemanticScholarClient(BaseClient):
-    """Client for the Semantic Scholar Academic Graph API."""
+    """Client for the Semantic Scholar Academic Graph API.
+
+    Uses a process-wide shared rate limiter (`shared_limiter_key = "s2"`)
+    because S2's free tier caps the entire account at ~1 req/sec even with
+    an API key; multiple parallel `SemanticScholarClient` instances would
+    otherwise multiply requests and trigger 429s.
+    """
+
+    shared_limiter_key: ClassVar[str | None] = "s2"
 
     def __init__(self, config: Config):
         super().__init__(

--- a/src/opencite/config.py
+++ b/src/opencite/config.py
@@ -14,8 +14,9 @@ from __future__ import annotations
 import logging
 import os
 import tomllib
-from dataclasses import dataclass, fields
+from dataclasses import dataclass, field, fields
 from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +44,10 @@ contact_email = ""
 timeout = 30.0
 max_retries = 3
 log_level = "WARNING"
+# Comma-separated list of sources to skip entirely. Useful when a source's
+# rate budget (e.g. Semantic Scholar's ~1 req/s) is the bottleneck and you
+# don't need its contribution.
+# disabled_sources = "s2,figshare"
 
 [defaults]
 max_results = 20
@@ -70,7 +75,13 @@ _TOML_MAP: dict[tuple[str, str], tuple[str, str]] = {
     ("defaults", "max_results"): ("default_max_results", "OPENCITE_MAX_RESULTS"),
     ("defaults", "format"): ("default_format", "OPENCITE_FORMAT"),
     ("defaults", "converter"): ("default_converter", "OPENCITE_CONVERTER"),
+    ("settings", "disabled_sources"): ("disabled_sources", "OPENCITE_DISABLED_SOURCES"),
 }
+
+
+def _split_csv(value: str) -> list[str]:
+    """Split a comma-separated string into a stripped, lowercased list."""
+    return [v.strip().lower() for v in value.split(",") if v.strip()]
 
 
 def _parse_dotenv(path: Path) -> dict[str, str]:
@@ -198,6 +209,13 @@ class Config:
     # Logging
     log_level: str = "WARNING"
 
+    # Sources the orchestrator/explorer should skip entirely. Accepts the
+    # canonical source keys used by SearchOrchestrator.ALL_SOURCES
+    # ("openalex", "s2", "pubmed", "arxiv", ...). Set via Python, TOML
+    # ([settings] disabled_sources = "s2,figshare"), or the
+    # OPENCITE_DISABLED_SOURCES env var (comma-separated).
+    disabled_sources: list[str] = field(default_factory=list)
+
     @classmethod
     def from_env(cls, config_path: Path | None = None) -> Config:
         """Create config from TOML, .env files, and environment variables.
@@ -208,7 +226,7 @@ class Config:
         3. .env files (~/.opencite/.env, then CWD .env)
         4. Environment variables
         """
-        kwargs: dict[str, str | float | int] = {}
+        kwargs: dict[str, Any] = {}
 
         # Layer 1: TOML config
         toml_values = _load_toml(config_path)
@@ -233,13 +251,15 @@ class Config:
 
         # Type-coerce values to match field types
         field_types = {f.name: f.type for f in fields(cls)}
-        coerced: dict[str, str | float | int] = {}
+        coerced: dict[str, Any] = {}
         for key, val in kwargs.items():
             expected_type = field_types.get(key, "str")
             if expected_type == "float" and not isinstance(val, float):
                 coerced[key] = float(val)
             elif expected_type == "int" and not isinstance(val, int):
                 coerced[key] = int(val)
+            elif expected_type == "list[str]" and isinstance(val, str):
+                coerced[key] = _split_csv(val)
             else:
                 coerced[key] = val
 

--- a/src/opencite/search.py
+++ b/src/opencite/search.py
@@ -19,6 +19,7 @@ from opencite.clients.semantic_scholar import SemanticScholarClient
 from opencite.clients.zenodo import ZenodoClient
 from opencite.dedup import deduplicate
 from opencite.models import IDType, Paper, SearchResult, parse_identifier
+from opencite.sources import canonicalize
 
 if TYPE_CHECKING:
     from opencite.config import Config
@@ -108,6 +109,12 @@ class SearchOrchestrator:
         """
         if sources is None:
             sources = ALL_SOURCES
+        # Honor disabled_sources as a baseline filter that can't be
+        # overridden by the per-call `sources=` argument. Callers who
+        # really want a disabled source can drop it from the config.
+        disabled = {canonicalize(d) for d in self.config.disabled_sources}
+        if disabled:
+            sources = tuple(s for s in sources if canonicalize(s) not in disabled)
 
         tasks: dict[str, asyncio.Task[list[Paper]]] = {}
 

--- a/src/opencite/sources.py
+++ b/src/opencite/sources.py
@@ -1,0 +1,51 @@
+"""Canonical source-name handling for `config.disabled_sources`.
+
+A small helper that lets `disabled_sources` accept user-friendly aliases
+("semantic-scholar", "semanticscholar") in addition to the canonical
+short keys used by the orchestrator ("s2", "openalex", "pubmed", ...).
+Kept independent of any client module to avoid circular imports.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+# Map any input alias -> canonical source key. Lookups normalize case and
+# treat '-'/'_' as interchangeable so users don't have to memorize the
+# exact spelling.
+_ALIASES: dict[str, str] = {
+    "openalex": "openalex",
+    "s2": "s2",
+    "semanticscholar": "s2",
+    "semantic_scholar": "s2",
+    "pubmed": "pubmed",
+    "ncbi": "pubmed",
+    "arxiv": "arxiv",
+    "biorxiv": "biorxiv",
+    "medrxiv": "medrxiv",
+    "osf": "osf",
+    "zenodo": "zenodo",
+    "figshare": "figshare",
+    "crossref": "crossref",
+    "core": "core",
+}
+
+
+def canonicalize(name: str) -> str:
+    """Return the canonical source key for an input alias.
+
+    Unknown names pass through (lowercased) so a typo doesn't silently
+    disable nothing; the caller can then log/warn if needed.
+    """
+    normalized = name.strip().lower().replace("-", "_")
+    return _ALIASES.get(normalized, normalized)
+
+
+def is_source_enabled(name: str, disabled: Iterable[str]) -> bool:
+    """True when `name` is not present in `disabled` (after canonicalization)."""
+    canon = canonicalize(name)
+    disabled_canon = {canonicalize(d) for d in disabled}
+    return canon not in disabled_canon

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import os
 
 import pytest
 
+from opencite.clients.base import BaseClient
 from opencite.config import Config, _load_all_dotenv
 from opencite.models import Author, IDSet, Paper, Source
 
@@ -14,6 +15,14 @@ from opencite.models import Author, IDSet, Paper, Source
 # at import time, before Config.from_env() would normally run.
 for _key, _value in _load_all_dotenv().items():
     os.environ.setdefault(_key, _value)
+
+
+@pytest.fixture(autouse=True)
+def _reset_shared_rate_limiters() -> None:
+    """Clear the per-process shared limiter registry between tests so
+    rate state and limiter identity from one test don't bleed into the next.
+    """
+    BaseClient.reset_shared_limiters()
 
 
 @pytest.fixture

--- a/tests/test_citation_explorer_branches.py
+++ b/tests/test_citation_explorer_branches.py
@@ -1,0 +1,307 @@
+"""Unit tests for CitationExplorer branches that don't need network access.
+
+Exercises `citing_papers`, `references`, `canonical_papers`, and
+`_lookup_seed` with mocked openalex/s2 clients so the previously
+integration-only paths get patch coverage.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from opencite.citations import CitationExplorer
+from opencite.config import Config
+from opencite.models import IDSet, IDType, Paper
+
+
+def _seed(doi: str = "", openalex_id: str = "", s2_id: str = "") -> Paper:
+    return Paper(
+        title="Seed",
+        ids=IDSet(doi=doi, openalex_id=openalex_id, s2_id=s2_id),
+    )
+
+
+def _stub_explorer(
+    seed: Paper | None = None,
+    *,
+    openalex_disabled: bool = False,
+    s2_disabled: bool = False,
+    openalex_citing: list[Paper] | None = None,
+    s2_citing: list[Paper] | None = None,
+    openalex_refs: list[Paper] | None = None,
+    s2_refs: list[Paper] | None = None,
+) -> CitationExplorer:
+    disabled = [
+        name
+        for name, flag in (("openalex", openalex_disabled), ("s2", s2_disabled))
+        if flag
+    ]
+    explorer = CitationExplorer(Config(disabled_sources=disabled))
+
+    if explorer._openalex is not None:
+        explorer._openalex.citing_papers = AsyncMock(
+            return_value=openalex_citing or []
+        )
+        explorer._openalex.references = AsyncMock(return_value=openalex_refs or [])
+        explorer._openalex.lookup_doi = AsyncMock(return_value=seed)
+        explorer._openalex.canonical_search = AsyncMock(return_value=[])
+    if explorer._s2 is not None:
+        explorer._s2.citing_papers = AsyncMock(return_value=s2_citing or [])
+        explorer._s2.references = AsyncMock(return_value=s2_refs or [])
+        explorer._s2.lookup = AsyncMock(return_value=seed)
+    return explorer
+
+
+class TestCitingPapers:
+    @pytest.mark.asyncio
+    async def test_unknown_seed_returns_empty_result(self):
+        explorer = _stub_explorer(seed=None)
+        explorer._s2.lookup = AsyncMock(return_value=None)
+        explorer._openalex.lookup_doi = AsyncMock(return_value=None)
+
+        result = await explorer.citing_papers("10.1234/x")
+        assert result.papers == []
+        assert result.direction == "citing"
+        assert result.seed_paper.title == "Unknown"
+
+    @pytest.mark.asyncio
+    async def test_gathers_from_both_when_both_ids_present(self):
+        seed = _seed(doi="10.1234/x", openalex_id="W1", s2_id="S1")
+        oa_paper = Paper(
+            title="OpenAlex citing paper alpha", ids=IDSet(doi="10.1234/alpha")
+        )
+        s2_paper = Paper(
+            title="Semantic Scholar citing beta", ids=IDSet(doi="10.1234/beta")
+        )
+        explorer = _stub_explorer(
+            seed=seed,
+            openalex_citing=[oa_paper],
+            s2_citing=[s2_paper],
+        )
+
+        result = await explorer.citing_papers("10.1234/x")
+        assert len(result.papers) == 2
+        explorer._openalex.citing_papers.assert_awaited_once()
+        explorer._s2.citing_papers.assert_awaited_once_with("S1", max_results=50)
+
+    @pytest.mark.asyncio
+    async def test_s2_doi_fallback_when_no_s2_id(self):
+        seed = _seed(doi="10.1234/x", openalex_id="W1")  # no s2_id
+        explorer = _stub_explorer(seed=seed, s2_citing=[Paper(title="x")])
+
+        await explorer.citing_papers("10.1234/x")
+        explorer._s2.citing_papers.assert_awaited_once_with(
+            "DOI:10.1234/x", max_results=50
+        )
+
+    @pytest.mark.asyncio
+    async def test_min_citations_filter_applied(self):
+        seed = _seed(openalex_id="W1")
+        lo = Paper(title="lo", ids=IDSet(doi="10.1/lo"), citation_count=5)
+        hi = Paper(title="hi", ids=IDSet(doi="10.1/hi"), citation_count=500)
+        explorer = _stub_explorer(seed=seed, openalex_citing=[lo, hi])
+
+        result = await explorer.citing_papers("10.1234/x", min_citations=100)
+        titles = [p.title for p in result.papers]
+        assert titles == ["hi"]
+
+    @pytest.mark.asyncio
+    async def test_only_openalex_when_s2_disabled(self):
+        seed = _seed(doi="10.1234/x", openalex_id="W1", s2_id="S1")
+        explorer = _stub_explorer(
+            seed=seed,
+            s2_disabled=True,
+            openalex_citing=[Paper(title="oa")],
+        )
+
+        result = await explorer.citing_papers("10.1234/x")
+        assert result.seed_paper.ids.openalex_id == "W1"
+        explorer._openalex.citing_papers.assert_awaited_once()
+        assert explorer._s2 is None
+        assert [p.title for p in result.papers] == ["oa"]
+
+
+class TestReferences:
+    @pytest.mark.asyncio
+    async def test_unknown_seed_returns_empty(self):
+        explorer = _stub_explorer(seed=None)
+        explorer._s2.lookup = AsyncMock(return_value=None)
+        explorer._openalex.lookup_doi = AsyncMock(return_value=None)
+
+        result = await explorer.references("10.1234/x")
+        assert result.papers == []
+        assert result.direction == "references"
+
+    @pytest.mark.asyncio
+    async def test_gathers_from_both_when_both_ids_present(self):
+        seed = _seed(doi="10.1234/x", openalex_id="W1", s2_id="S1")
+        explorer = _stub_explorer(
+            seed=seed,
+            openalex_refs=[
+                Paper(title="OpenAlex reference one", ids=IDSet(doi="10.1234/r1"))
+            ],
+            s2_refs=[
+                Paper(title="S2 reference two", ids=IDSet(doi="10.1234/r2"))
+            ],
+        )
+
+        result = await explorer.references("10.1234/x")
+        assert len(result.papers) == 2
+
+    @pytest.mark.asyncio
+    async def test_s2_doi_fallback_for_references(self):
+        seed = _seed(doi="10.1234/x", openalex_id="W1")
+        explorer = _stub_explorer(seed=seed, s2_refs=[Paper(title="ref")])
+
+        await explorer.references("10.1234/x")
+        explorer._s2.references.assert_awaited_once_with(
+            "DOI:10.1234/x", max_results=50
+        )
+
+
+class TestCanonicalPapers:
+    @pytest.mark.asyncio
+    async def test_delegates_to_openalex(self):
+        seed = _seed(openalex_id="W1")
+        explorer = _stub_explorer(seed=seed)
+        explorer._openalex.canonical_search = AsyncMock(
+            return_value=[Paper(title="top")]
+        )
+
+        result = await explorer.canonical_papers("topic", max_results=5)
+        assert [p.title for p in result] == ["top"]
+        explorer._openalex.canonical_search.assert_awaited_once()
+
+
+class TestLookupSeed:
+    @pytest.mark.asyncio
+    async def test_doi_merges_s2_and_openalex(self):
+        s2_paper = Paper(title="merged", ids=IDSet(doi="10.1234/x", s2_id="S1"))
+        oa_paper = Paper(title="merged", ids=IDSet(doi="10.1234/x", openalex_id="W1"))
+        explorer = _stub_explorer(seed=s2_paper)
+        explorer._openalex.lookup_doi = AsyncMock(return_value=oa_paper)
+
+        result = await explorer._lookup_seed(IDType.DOI, "10.1234/x")
+        assert result is not None
+        assert result.ids.s2_id == "S1"
+        assert result.ids.openalex_id == "W1"
+
+    @pytest.mark.asyncio
+    async def test_doi_falls_back_to_openalex_when_s2_misses(self):
+        explorer = _stub_explorer(seed=None)
+        explorer._s2.lookup = AsyncMock(return_value=None)
+        oa_paper = Paper(title="oa", ids=IDSet(doi="10.1234/x"))
+        explorer._openalex.lookup_doi = AsyncMock(return_value=oa_paper)
+
+        result = await explorer._lookup_seed(IDType.DOI, "10.1234/x")
+        assert result is oa_paper
+
+    @pytest.mark.asyncio
+    async def test_pmid_lookup_via_s2(self):
+        paper = Paper(title="x", ids=IDSet(pmid="12345"))
+        explorer = _stub_explorer(seed=paper)
+        explorer._s2.lookup = AsyncMock(return_value=paper)
+
+        result = await explorer._lookup_seed(IDType.PMID, "12345")
+        assert result is paper
+
+    @pytest.mark.asyncio
+    async def test_pmid_lookup_enriches_with_openalex_when_doi_known(self):
+        s2_paper = Paper(title="x", ids=IDSet(pmid="12345", doi="10.1234/x"))
+        oa_paper = Paper(
+            title="x",
+            ids=IDSet(pmid="12345", doi="10.1234/x", openalex_id="W1"),
+        )
+        explorer = _stub_explorer(seed=None)
+        explorer._s2.lookup = AsyncMock(return_value=s2_paper)
+        explorer._openalex.lookup_doi = AsyncMock(return_value=oa_paper)
+
+        result = await explorer._lookup_seed(IDType.PMID, "12345")
+        # The OpenAlex enrichment merged in the W1 id.
+        assert result is not None
+        assert result.ids.openalex_id == "W1"
+        explorer._openalex.lookup_doi.assert_awaited_once_with("10.1234/x")
+
+    @pytest.mark.asyncio
+    async def test_arxiv_lookup_via_s2(self):
+        paper = Paper(title="x", ids=IDSet(arxiv_id="2106.15928"))
+        explorer = _stub_explorer(seed=paper)
+        explorer._s2.lookup = AsyncMock(return_value=paper)
+
+        result = await explorer._lookup_seed(IDType.ARXIV, "2106.15928")
+        assert result is paper
+        explorer._s2.lookup.assert_awaited_once_with("ARXIV:2106.15928")
+
+    @pytest.mark.asyncio
+    async def test_openalex_id_lookup(self):
+        paper = Paper(title="x", ids=IDSet(openalex_id="W1"))
+        explorer = _stub_explorer(seed=paper)
+
+        result = await explorer._lookup_seed(IDType.OPENALEX, "W1")
+        explorer._openalex.lookup_doi.assert_awaited_once_with("W1")
+        assert result is paper
+
+    @pytest.mark.asyncio
+    async def test_s2_id_lookup(self):
+        paper = Paper(title="x", ids=IDSet(s2_id="abc123"))
+        explorer = _stub_explorer(seed=paper)
+        explorer._s2.lookup = AsyncMock(return_value=paper)
+
+        result = await explorer._lookup_seed(IDType.S2, "abc123")
+        assert result is paper
+
+    @pytest.mark.asyncio
+    async def test_pmcid_returns_none_when_no_lookup_path(self):
+        # PMCID isn't handled by either of the explorer's clients.
+        explorer = _stub_explorer(seed=None)
+        result = await explorer._lookup_seed(IDType.PMCID, "PMC1234")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_lookup_when_s2_disabled_uses_openalex(self):
+        oa_paper = Paper(title="oa", ids=IDSet(doi="10.1234/x"))
+        explorer = _stub_explorer(seed=None, s2_disabled=True)
+        explorer._openalex.lookup_doi = AsyncMock(return_value=oa_paper)
+
+        result = await explorer._lookup_seed(IDType.DOI, "10.1234/x")
+        assert result is oa_paper
+
+    @pytest.mark.asyncio
+    async def test_lookup_when_openalex_disabled_uses_s2(self):
+        s2_paper = Paper(title="s2", ids=IDSet(doi="10.1234/x"))
+        explorer = _stub_explorer(seed=s2_paper, openalex_disabled=True)
+
+        result = await explorer._lookup_seed(IDType.DOI, "10.1234/x")
+        assert result is s2_paper
+
+
+class TestContextManagerSkipsDisabledClients:
+    @pytest.mark.asyncio
+    async def test_aenter_aexit_when_s2_disabled(self):
+        explorer = CitationExplorer(Config(disabled_sources=["s2"]))
+        # Avoid network: replace openalex enter/exit with no-op mocks.
+        explorer._openalex.__aenter__ = AsyncMock(return_value=explorer._openalex)
+        explorer._openalex.__aexit__ = AsyncMock(return_value=None)
+
+        async with explorer:
+            pass
+
+        explorer._openalex.__aenter__.assert_awaited_once()
+        explorer._openalex.__aexit__.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_aenter_aexit_with_both_clients_enabled(self):
+        explorer = CitationExplorer(Config())
+        for client in (explorer._openalex, explorer._s2):
+            client.__aenter__ = AsyncMock(return_value=client)
+            client.__aexit__ = AsyncMock(return_value=None)
+
+        async with explorer:
+            pass
+
+        explorer._openalex.__aenter__.assert_awaited_once()
+        explorer._s2.__aenter__.assert_awaited_once()
+        explorer._openalex.__aexit__.assert_awaited_once()
+        explorer._s2.__aexit__.assert_awaited_once()

--- a/tests/test_disabled_sources.py
+++ b/tests/test_disabled_sources.py
@@ -47,16 +47,56 @@ class TestCitationExplorerDisabledSources:
 
 
 class TestSearchOrchestratorRespectsDisabledSources:
-    def test_disabled_sources_filtered_from_default_search(self):
-        # Build the orchestrator and inspect the filter logic by
-        # mocking out per-client search; here we just verify the filter
-        # math via canonicalize behavior used by SearchOrchestrator.
+    def test_disabled_sources_round_trips_through_orchestrator(self):
         config = Config(disabled_sources=["figshare", "core"])
         orchestrator = SearchOrchestrator(config)
-        # disabled_sources is a config attribute consumed at .search() time;
-        # verify it round-trips through the orchestrator's config.
         assert "figshare" in orchestrator.config.disabled_sources
         assert "core" in orchestrator.config.disabled_sources
+
+    @pytest.mark.asyncio
+    async def test_disabled_sources_skip_real_client_dispatch(self):
+        """End-to-end: a disabled source's `search` method must not be awaited."""
+        from unittest.mock import AsyncMock
+
+        orchestrator = SearchOrchestrator(
+            Config(disabled_sources=["s2", "figshare", "core"])
+        )
+        for attr in (
+            "_openalex",
+            "_s2",
+            "_pubmed",
+            "_arxiv",
+            "_biorxiv",
+            "_medrxiv",
+            "_osf",
+            "_zenodo",
+            "_figshare",
+            "_crossref",
+            "_core",
+        ):
+            getattr(orchestrator, attr).search = AsyncMock(return_value=[])
+
+        await orchestrator.search("query")
+
+        orchestrator._s2.search.assert_not_called()
+        orchestrator._figshare.search.assert_not_called()
+        orchestrator._core.search.assert_not_called()
+        orchestrator._openalex.search.assert_awaited_once()
+        orchestrator._arxiv.search.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_disabled_overrides_per_call_sources_arg(self):
+        """Even an explicit `sources=` argument cannot re-enable a disabled source."""
+        from unittest.mock import AsyncMock
+
+        orchestrator = SearchOrchestrator(Config(disabled_sources=["s2"]))
+        orchestrator._s2.search = AsyncMock(return_value=[])
+        orchestrator._openalex.search = AsyncMock(return_value=[])
+
+        await orchestrator.search("query", sources=("openalex", "s2"))
+
+        orchestrator._s2.search.assert_not_called()
+        orchestrator._openalex.search.assert_awaited_once()
 
 
 class TestConfigDisabledSourcesParsing:

--- a/tests/test_disabled_sources.py
+++ b/tests/test_disabled_sources.py
@@ -1,0 +1,75 @@
+"""Tests for `Config.disabled_sources` integration."""
+
+from __future__ import annotations
+
+import pytest
+
+from opencite.citations import CitationExplorer
+from opencite.config import Config
+from opencite.search import SearchOrchestrator
+
+
+class TestCitationExplorerDisabledSources:
+    def test_default_constructs_both_clients(self):
+        config = Config()
+        explorer = CitationExplorer(config)
+        assert explorer._openalex is not None
+        assert explorer._s2 is not None
+
+    def test_disabling_s2_skips_s2_client(self):
+        config = Config(disabled_sources=["s2"])
+        explorer = CitationExplorer(config)
+        assert explorer._openalex is not None
+        assert explorer._s2 is None
+
+    def test_alias_disables_s2(self):
+        config = Config(disabled_sources=["semantic-scholar"])
+        explorer = CitationExplorer(config)
+        assert explorer._s2 is None
+
+    def test_disabling_openalex_skips_openalex_client(self):
+        config = Config(disabled_sources=["openalex"])
+        explorer = CitationExplorer(config)
+        assert explorer._openalex is None
+        assert explorer._s2 is not None
+
+    def test_disabling_both_raises(self):
+        config = Config(disabled_sources=["openalex", "s2"])
+        with pytest.raises(ValueError, match="at least one"):
+            CitationExplorer(config)
+
+    @pytest.mark.asyncio
+    async def test_canonical_papers_raises_when_openalex_disabled(self):
+        config = Config(disabled_sources=["openalex"])
+        explorer = CitationExplorer(config)
+        with pytest.raises(RuntimeError, match="openalex"):
+            await explorer.canonical_papers("anything")
+
+
+class TestSearchOrchestratorRespectsDisabledSources:
+    def test_disabled_sources_filtered_from_default_search(self):
+        # Build the orchestrator and inspect the filter logic by
+        # mocking out per-client search; here we just verify the filter
+        # math via canonicalize behavior used by SearchOrchestrator.
+        config = Config(disabled_sources=["figshare", "core"])
+        orchestrator = SearchOrchestrator(config)
+        # disabled_sources is a config attribute consumed at .search() time;
+        # verify it round-trips through the orchestrator's config.
+        assert "figshare" in orchestrator.config.disabled_sources
+        assert "core" in orchestrator.config.disabled_sources
+
+
+class TestConfigDisabledSourcesParsing:
+    def test_default_is_empty(self):
+        assert Config().disabled_sources == []
+
+    def test_env_var_csv_is_parsed_into_list(self, monkeypatch):
+        monkeypatch.setenv("OPENCITE_DISABLED_SOURCES", "s2, figshare ,core")
+        config = Config.from_env()
+        assert config.disabled_sources == ["s2", "figshare", "core"]
+
+    def test_env_var_empty_string_yields_empty_list(self, monkeypatch):
+        monkeypatch.setenv("OPENCITE_DISABLED_SOURCES", "")
+        config = Config.from_env()
+        # An explicitly empty value should still parse cleanly.
+        assert config.disabled_sources == []

--- a/tests/test_shared_rate_limiter.py
+++ b/tests/test_shared_rate_limiter.py
@@ -1,0 +1,116 @@
+"""Tests for the per-process shared rate limiter on BaseClient.
+
+The intent is to verify that subclasses opting in via `shared_limiter_key`
+all see the same RateLimiter instance, so concurrent callers can't blow
+through a tight per-source budget (e.g. Semantic Scholar's ~1 req/sec).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import ClassVar
+
+import pytest
+
+from opencite.clients.base import BaseClient, RateLimiter
+from opencite.clients.id_converter import IDConverterClient
+from opencite.clients.openalex import OpenAlexClient
+from opencite.clients.pubmed import PubMedClient
+from opencite.clients.semantic_scholar import SemanticScholarClient
+from opencite.config import Config
+
+
+class _UnsharedClient(BaseClient):
+    """Sentinel: a client class with no shared_limiter_key."""
+
+    def _default_headers(self) -> dict[str, str]:
+        return {}
+
+
+class _SharedClient(BaseClient):
+    """Sentinel: a client class that opts in to a shared limiter."""
+
+    shared_limiter_key: ClassVar[str | None] = "shared-test"
+
+    def _default_headers(self) -> dict[str, str]:
+        return {}
+
+
+class TestSharedLimiterOptIn:
+    def test_unshared_clients_get_independent_limiters(self):
+        config = Config()
+        a = _UnsharedClient(config, base_url="https://x", rate_limit=10.0)
+        b = _UnsharedClient(config, base_url="https://x", rate_limit=10.0)
+        assert a.rate_limiter is not b.rate_limiter
+
+    def test_shared_clients_get_the_same_limiter(self):
+        config = Config()
+        a = _SharedClient(config, base_url="https://a", rate_limit=10.0)
+        b = _SharedClient(config, base_url="https://b", rate_limit=10.0)
+        assert a.rate_limiter is b.rate_limiter
+
+    def test_reset_clears_registry(self):
+        config = Config()
+        a = _SharedClient(config, base_url="https://a", rate_limit=10.0)
+        BaseClient.reset_shared_limiters()
+        b = _SharedClient(config, base_url="https://a", rate_limit=10.0)
+        assert a.rate_limiter is not b.rate_limiter
+
+
+class TestRealClientsShareBudgets:
+    def test_s2_clients_share_one_limiter(self):
+        config = Config()
+        a = SemanticScholarClient(config)
+        b = SemanticScholarClient(config)
+        assert a.rate_limiter is b.rate_limiter
+
+    def test_openalex_clients_share_one_limiter(self):
+        config = Config()
+        a = OpenAlexClient(config)
+        b = OpenAlexClient(config)
+        assert a.rate_limiter is b.rate_limiter
+
+    def test_pubmed_and_id_converter_share_ncbi_budget(self):
+        config = Config()
+        a = PubMedClient(config)
+        b = IDConverterClient(config)
+        # Both NCBI eutils endpoints share one budget so the per-key
+        # ~10 req/sec ceiling isn't doubled.
+        assert a.rate_limiter is b.rate_limiter
+
+    def test_s2_and_openalex_have_separate_budgets(self):
+        config = Config()
+        s2 = SemanticScholarClient(config)
+        oa = OpenAlexClient(config)
+        assert s2.rate_limiter is not oa.rate_limiter
+
+
+class TestRateLimiterAcrossLoops:
+    """Acquiring from a freshly-created event loop must not raise."""
+
+    def test_acquire_in_two_sequential_loops(self):
+        rl = RateLimiter(rate=100.0, burst=2)
+        # First loop drains a token, second loop reuses the limiter.
+        asyncio.run(rl.acquire())
+        asyncio.run(rl.acquire())
+
+
+class TestSharedLimiterSerializesRate:
+    """Two clients sharing a 1 req/s limiter must observe the limit jointly."""
+
+    @pytest.mark.asyncio
+    async def test_shared_limiter_caps_combined_throughput(self):
+        config = Config()
+        # Force a deterministic, low rate via the shared registry.
+        BaseClient.reset_shared_limiters()
+        a = _SharedClient(config, base_url="https://a", rate_limit=10.0)
+        _SharedClient(config, base_url="https://b", rate_limit=10.0)
+        # First call drains the single burst token; second waits ~0.1s
+        # because both instances share one bucket.
+        await a.rate_limiter.acquire()
+        start = time.monotonic()
+        await a.rate_limiter.acquire()
+        elapsed = time.monotonic() - start
+        # At 10 req/s, refill time is 0.1s. Allow generous margin.
+        assert elapsed >= 0.05

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,0 +1,42 @@
+"""Tests for opencite.sources (source-name canonicalization)."""
+
+from __future__ import annotations
+
+from opencite.sources import canonicalize, is_source_enabled
+
+
+class TestCanonicalize:
+    def test_canonical_keys_pass_through(self):
+        for key in ("openalex", "s2", "pubmed", "arxiv", "biorxiv", "medrxiv"):
+            assert canonicalize(key) == key
+
+    def test_known_aliases_resolve(self):
+        assert canonicalize("semanticscholar") == "s2"
+        assert canonicalize("semantic_scholar") == "s2"
+        assert canonicalize("semantic-scholar") == "s2"
+        assert canonicalize("ncbi") == "pubmed"
+
+    def test_case_and_whitespace_insensitive(self):
+        assert canonicalize("  Semantic-Scholar  ") == "s2"
+        assert canonicalize("OPENALEX") == "openalex"
+
+    def test_unknown_passes_through_lowercased(self):
+        # Typos shouldn't silently match -- the caller can warn if needed.
+        assert canonicalize("semanticscholr") == "semanticscholr"
+
+
+class TestIsSourceEnabled:
+    def test_empty_disabled_list_means_enabled(self):
+        assert is_source_enabled("s2", []) is True
+
+    def test_canonical_match_disables(self):
+        assert is_source_enabled("s2", ["s2"]) is False
+
+    def test_alias_in_disabled_matches_canonical_name(self):
+        assert is_source_enabled("s2", ["semantic-scholar"]) is False
+        assert is_source_enabled("semanticscholar", ["s2"]) is False
+
+    def test_other_sources_unaffected(self):
+        disabled = ["s2"]
+        assert is_source_enabled("openalex", disabled) is True
+        assert is_source_enabled("pubmed", disabled) is True


### PR DESCRIPTION
Closes #34.

## Why

Issue #34 traces a concrete 429 storm: two parallel `CitationExplorer.citing_papers(anchor)` calls hit the same Semantic Scholar paper 0.85s apart and the second is rate-limited, then sits through a 5s backoff in `clients/base.py`. Root cause: each `BaseClient(config)` constructed its own `RateLimiter`, so Nx parallel callers mean Nx rate budget. The retry-with-backoff was masking the multiplication.

The downstream consumer (`nemarOrg/nemar-citations`, weekly cron over ~550 datasets) was working around it by throttling the outer fan-out to concurrency=1, which serialized the OpenAlex side unnecessarily and roughly doubled wall-clock time.

## What

Two related, self-contained changes.

### 1. Process-wide shared rate limiter (opt-in)

`BaseClient` now exposes a `shared_limiter_key: ClassVar[str | None]`. Subclasses that opt in share one `RateLimiter` instance across every `BaseClient(config)` constructed in the process. Subclasses without a key keep per-instance limiters (existing behavior, used by the per-call `_ConcreteClient` test scaffold).

Opted in:
- `SemanticScholarClient` -> `s2`
- `OpenAlexClient` -> `openalex`
- `PubMedClient` + `IDConverterClient` -> `ncbi_eutils` (both hit NCBI eutils under the same per-key budget)

`RateLimiter` now lazily (re)creates its `asyncio.Lock` when invoked from a new event loop, so the same shared instance survives pytest-asyncio's per-function loops without `attached to a different loop` errors.

A conftest autouse fixture clears the registry between tests so rate state from one test can't leak into the next.

### 2. `Config.disabled_sources` opt-out

New `list[str]` field, settable three ways:
- Python: `Config(disabled_sources=[\"s2\"])`
- TOML: `[settings] disabled_sources = \"s2,figshare\"`
- env: `OPENCITE_DISABLED_SOURCES=s2,figshare`

A small `opencite.sources` module canonicalizes user-friendly aliases (`semantic-scholar`, `semanticscholar`, `ncbi`, ...) so callers don't have to memorize the exact short keys.

Behavior:
- `CitationExplorer` never constructs the disabled clients. Both disabled raises at construction time. `canonical_papers` raises a clear `RuntimeError` if `openalex` is disabled (no substitute available).
- `SearchOrchestrator.search` applies `disabled_sources` as a baseline filter on top of any per-call `sources=` argument.

## Test plan

- [x] 27 new unit tests (`test_sources.py`, `test_shared_rate_limiter.py`, `test_disabled_sources.py`)
- [x] All 664 unit tests pass on 3.13
- [x] `ruff check src/ tests/` clean
- [ ] Integration tests run on merge to main (existing job)

## Notes

- The shared limiter is opt-in per subclass to keep the test scaffolding's `_ConcreteClient` and lightly-used sources (arXiv, bioRxiv, CORE, etc.) unaffected; their request volume per process is well below their budgets.
- Disabling both `openalex` and `s2` in the explorer raises rather than silently returning empty results, since there's nothing left to query.