### PR TITLE
Report OA status and per-PDF license sidecar (#35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,33 @@ wiley_tdm = "your_token"
 springer = "your_key"
 ```
 
+## Redistribution and licensing
+
+OpenCite retrieves PDFs and markdown for you and reports what it found, but it
+does not enforce a redistribution policy. The publication-vs-reuse decision
+belongs to the caller.
+
+What we report:
+
+- **`Paper.oa_status`** -- the OpenAlex Open Access status (`gold`, `hybrid`,
+  `green`, `bronze`, `closed`, `diamond`, or empty when unknown). `is_oa = True`
+  collapses all open categories together; `oa_status` distinguishes them.
+  Notably, **bronze** is free-to-read but not openly licensed.
+- **`PDFLocation.license` and `version`** -- per-source license string
+  (`cc-by`, `cc-by-nc`, etc.) and version (`publishedVersion`,
+  `acceptedVersion`, `submittedVersion`) where the upstream API surfaces them.
+  Available in `opencite lookup --format json --verbose` and `opencite search`.
+- **`<pdf>.license.json`** -- a sidecar written next to every downloaded PDF
+  containing `{url, source, license, version, oa_status, publisher_tdm, doi,
+  retrieved_at}`. A later "is this PDF safe to commit?" check can run by
+  scanning sidecars without re-querying the original Paper.
+
+If your pipeline publishes its artifacts (e.g. commits PDFs/markdown to a
+public repo), be deliberate about which sources you enable. Publisher TDM
+tokens (Elsevier, Wiley, Springer) almost universally prohibit redistribution
+of the bytes they return; the sidecar's `publisher_tdm: true` flag is a
+machine-readable signal for downstream scanners.
+
 ## License
 
 MIT

--- a/src/opencite/clients/openalex.py
+++ b/src/opencite/clients/openalex.py
@@ -303,9 +303,15 @@ class OpenAlexClient(BaseClient):
             if grant:
                 grants.append(grant)
 
-        # OA status
+        # OA status. OpenAlex distinguishes gold / hybrid / green / bronze /
+        # closed / diamond; `is_oa` collapses all of these to a boolean and
+        # doesn't communicate the redistribution implications (bronze, for
+        # example, is free-to-read but not reusably licensed). Keep `is_oa`
+        # for backward compatibility and surface the enum separately as
+        # `oa_status` so downstream consumers can decide for themselves.
         oa_obj = work.get("open_access") or {}
         is_oa = oa_obj.get("is_oa", False) or False
+        oa_status = oa_obj.get("oa_status") or ""
 
         return Paper(
             title=work.get("title", ""),
@@ -323,6 +329,7 @@ class OpenAlexClient(BaseClient):
             url=doi_raw if doi_raw else work.get("id", ""),
             pdf_locations=pdf_locations,
             is_oa=is_oa,
+            oa_status=oa_status,
             data_sources={"openalex"},
             grants=grants,
         )

--- a/src/opencite/dedup.py
+++ b/src/opencite/dedup.py
@@ -141,6 +141,7 @@ def merge_papers(existing: Paper, new: Paper) -> Paper:
         source_venue=source_venue,
         data_sources=merged_sources,
         is_oa=existing.is_oa or new.is_oa,
+        oa_status=existing.oa_status or new.oa_status,
         is_retracted=existing.is_retracted or new.is_retracted,
         year=existing.year or new.year,
         publication_date=existing.publication_date or new.publication_date,

--- a/src/opencite/dedup.py
+++ b/src/opencite/dedup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import replace
 from typing import TYPE_CHECKING
 
@@ -9,6 +10,8 @@ from opencite.utils import normalize_title, titles_similar
 
 if TYPE_CHECKING:
     from opencite.models import Paper
+
+logger = logging.getLogger(__name__)
 
 
 def deduplicate(papers: list[Paper]) -> list[Paper]:
@@ -124,6 +127,18 @@ def merge_papers(existing: Paper, new: Paper) -> Paper:
 
     # BibTeX: prefer existing if present
     bibtex = existing._bibtex or new._bibtex
+
+    # oa_status precedence: existing wins (consistent with sibling fields).
+    # When two sources legitimately disagree (e.g. preprint copy is `green`,
+    # published copy is `gold`) the existing-wins choice is arbitrary -- log
+    # it so an operator auditing a surprising classification has a breadcrumb.
+    if existing.oa_status and new.oa_status and existing.oa_status != new.oa_status:
+        logger.debug(
+            "oa_status mismatch during merge: keeping %r over %r for %r",
+            existing.oa_status,
+            new.oa_status,
+            existing.doi or existing.title,
+        )
 
     return replace(
         existing,

--- a/src/opencite/formatters/csv_fmt.py
+++ b/src/opencite/formatters/csv_fmt.py
@@ -22,6 +22,7 @@ _FIELDS = [
     "citation_count",
     "url",
     "is_oa",
+    "oa_status",
     "data_sources",
 ]
 
@@ -63,5 +64,6 @@ def _paper_to_row(paper: Paper) -> dict[str, str]:
         "citation_count": str(paper.citation_count),
         "url": paper.url,
         "is_oa": str(paper.is_oa),
+        "oa_status": paper.oa_status,
         "data_sources": ", ".join(sorted(paper.data_sources)),
     }

--- a/src/opencite/formatters/json_fmt.py
+++ b/src/opencite/formatters/json_fmt.py
@@ -47,6 +47,7 @@ def _paper_to_dict(paper: Paper, verbose: bool = False) -> dict:
         "citation_count": paper.citation_count,
         "url": paper.url,
         "is_oa": paper.is_oa,
+        "oa_status": paper.oa_status,
         "data_sources": sorted(paper.data_sources),
     }
 
@@ -69,8 +70,16 @@ def _paper_to_dict(paper: Paper, verbose: bool = False) -> dict:
         if paper.mesh_terms:
             d["mesh_terms"] = paper.mesh_terms
         if paper.pdf_locations:
+            # Surface `license` and `version` per location so downstream
+            # consumers can make redistribution decisions without re-querying.
             d["pdf_locations"] = [
-                {"url": loc.url, "source": loc.source, "is_oa": loc.is_oa}
+                {
+                    "url": loc.url,
+                    "source": loc.source,
+                    "is_oa": loc.is_oa,
+                    "version": loc.version,
+                    "license": loc.license,
+                }
                 for loc in paper.pdf_locations
             ]
         if paper.grants:

--- a/src/opencite/models.py
+++ b/src/opencite/models.py
@@ -150,6 +150,15 @@ class Paper:
     url: str = ""
     pdf_locations: list[PDFLocation] = field(default_factory=list)
     is_oa: bool = False
+    # OpenAlex-style enum: "gold", "hybrid", "green", "bronze", "closed",
+    # "diamond", or "" when unknown. `is_oa = True` collapses gold/hybrid/
+    # green/bronze together, but the redistribution implications differ
+    # (e.g. bronze is free-to-read but not openly licensed). Consumers
+    # publishing artifacts based on PDFs we retrieve should consult this
+    # field rather than `is_oa` alone. opencite reports `oa_status` but
+    # does not filter on it -- the publication-vs-redistribution decision
+    # belongs to the caller.
+    oa_status: str = ""
 
     # Provenance
     data_sources: set[str] = field(default_factory=set)

--- a/src/opencite/pdf.py
+++ b/src/opencite/pdf.py
@@ -12,7 +12,7 @@ import httpx
 
 from opencite.clients.id_converter import IDConverterClient
 from opencite.clients.unpaywall import UnpaywallClient
-from opencite.models import IDType, Paper, parse_identifier
+from opencite.models import IDType, Paper, PDFLocation, parse_identifier
 
 if TYPE_CHECKING:
     from opencite.config import Config
@@ -155,8 +155,15 @@ class PDFRetriever:
             logger.debug("Trying PDF URL: %s", url)
             result = await self._try_download(url, dest, failures)
             if result:
-                _write_license_sidecar(result, url, paper)
-                return result
+                pdf_path, final_url = result
+                # Pass both URLs: the original is what's stored in
+                # paper.pdf_locations so it's used for the metadata match;
+                # the final post-redirect URL is what the bytes actually
+                # came from and is used for source inference. This matters
+                # for doi.org content negotiation that resolves through a
+                # publisher's TDM endpoint.
+                _write_license_sidecar(pdf_path, url, final_url, paper)
+                return pdf_path
 
         # Report failures
         self._report_failures(identifier, failures, paper)
@@ -257,8 +264,14 @@ class PDFRetriever:
         url: str,
         dest: Path,
         failures: list[tuple[str, str]],
-    ) -> Path | None:
-        """Try downloading a PDF from a URL."""
+    ) -> tuple[Path, str] | None:
+        """Try downloading a PDF from a URL.
+
+        Returns `(dest, final_url)` on success where `final_url` is the
+        URL the bytes actually came from after redirects (used by the
+        license sidecar so that doi.org redirects to a publisher TDM
+        endpoint are classified by their resolved source, not by `doi`).
+        """
         headers: dict[str, str] = {}
 
         # Add publisher auth headers
@@ -292,7 +305,7 @@ class PDFRetriever:
 
                 dest.write_bytes(resp.content)
                 logger.info("Downloaded PDF to %s (%d bytes)", dest, len(resp.content))
-                return dest
+                return dest, str(resp.url)
 
         except httpx.HTTPStatusError as e:
             status = e.response.status_code
@@ -516,7 +529,12 @@ def _infer_source_from_url(url: str) -> str:
     return "unknown"
 
 
-def _write_license_sidecar(pdf_path: Path, url: str, paper: Paper | None) -> None:
+def _write_license_sidecar(
+    pdf_path: Path,
+    url: str,
+    final_url: str | None,
+    paper: Paper | None,
+) -> None:
     """Write `<pdf>.license.json` next to a downloaded PDF.
 
     Captures the URL that produced the bytes, the inferred source, and
@@ -526,13 +544,27 @@ def _write_license_sidecar(pdf_path: Path, url: str, paper: Paper | None) -> Non
     are explicitly flagged because their terms typically prohibit
     redistribution of the bytes; the caller decides what to do with that.
 
+    Args:
+        pdf_path: Path of the downloaded PDF (sidecar lives next to it).
+        url: Original URL attempted (matched against `paper.pdf_locations`
+            since that's the string stored there).
+        final_url: Post-redirect URL the bytes actually came from. Used
+            for source inference so a doi.org redirect that resolves to a
+            publisher TDM endpoint is classified by its true source. Falls
+            back to `url` when None.
+        paper: Source paper metadata; may be None when downloaded
+            without prior enrichment.
+
     Failure to write the sidecar is logged but never raises -- the PDF
-    itself is the primary artifact.
+    itself is the primary artifact. Catches OSError (filesystem) and
+    TypeError/ValueError (json.dumps on an unexpected payload shape).
     """
     try:
-        # Try to match the successful URL to a PDFLocation we already have
-        # license/version metadata for; fall back to URL inference otherwise.
-        matched = None
+        inference_url = final_url or url
+        # Match against the URL we put in paper.pdf_locations (the pre-redirect
+        # one); if no match, infer from the final URL so doi.org redirects
+        # are classified by where the bytes actually came from.
+        matched: PDFLocation | None = None
         if paper is not None:
             for loc in paper.pdf_locations:
                 if loc.url == url:
@@ -543,22 +575,36 @@ def _write_license_sidecar(pdf_path: Path, url: str, paper: Paper | None) -> Non
             source = matched.source
             license_value = matched.license
             version = matched.version
-            is_oa = matched.is_oa
+            bytes_is_oa = matched.is_oa
         else:
-            source = _infer_source_from_url(url)
+            source = _infer_source_from_url(inference_url)
             license_value = ""
             version = ""
-            is_oa = paper.is_oa if paper is not None else False
+            # Don't pull is_oa from paper.is_oa here: the metadata is about
+            # the bytes we just downloaded, not the paper-in-general. A
+            # publisher-TDM endpoint returning the published version of an
+            # OA paper is still not OA-redistributable bytes.
+            bytes_is_oa = False
+            logger.debug(
+                "no PDFLocation match for downloaded URL %s; inferring source %s",
+                inference_url,
+                source,
+            )
 
         publisher_tdm = source.startswith("publisher:")
+        # publisher_tdm bytes are never OA-redistributable regardless of
+        # what `paper.pdf_locations` claimed, so override defensively.
+        if publisher_tdm:
+            bytes_is_oa = False
 
         sidecar = {
             "pdf_filename": pdf_path.name,
             "url": url,
+            "final_url": final_url or url,
             "source": source,
             "license": license_value,
             "version": version,
-            "is_oa": is_oa,
+            "is_oa": bytes_is_oa,
             "oa_status": paper.oa_status if paper is not None else "",
             "publisher_tdm": publisher_tdm,
             "doi": paper.doi if paper is not None else "",
@@ -573,5 +619,7 @@ def _write_license_sidecar(pdf_path: Path, url: str, paper: Paper | None) -> Non
         }
         sidecar_path = pdf_path.with_suffix(pdf_path.suffix + ".license.json")
         sidecar_path.write_text(json.dumps(sidecar, indent=2))
-    except OSError as e:
-        logger.warning("Failed to write license sidecar for %s: %s", pdf_path, e)
+    except (OSError, TypeError, ValueError) as e:
+        logger.warning(
+            "Failed to write license sidecar for %s: %s", pdf_path, e, exc_info=True
+        )

--- a/src/opencite/pdf.py
+++ b/src/opencite/pdf.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 import logging
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -153,6 +155,7 @@ class PDFRetriever:
             logger.debug("Trying PDF URL: %s", url)
             result = await self._try_download(url, dest, failures)
             if result:
+                _write_license_sidecar(result, url, paper)
                 return result
 
         # Report failures
@@ -485,3 +488,90 @@ class PDFRetriever:
         from opencite.utils import make_paper_filename
 
         return make_paper_filename(paper, identifier)
+
+
+def _infer_source_from_url(url: str) -> str:
+    """Best-effort source label for a downloaded URL.
+
+    Used only for the license sidecar when the URL didn't come from a
+    PDFLocation we already have provenance for (e.g. publisher-API or
+    direct preprint URLs we synthesize in `_collect_urls`).
+    """
+    if "api.elsevier.com" in url:
+        return "publisher:elsevier"
+    if "api.wiley.com" in url:
+        return "publisher:wiley"
+    if "api.springernature.com" in url:
+        return "publisher:springer"
+    if "arxiv.org" in url:
+        return "arxiv"
+    if "ncbi.nlm.nih.gov/pmc" in url or "pmc.ncbi.nlm.nih.gov" in url:
+        return "pmc"
+    if "biorxiv.org" in url:
+        return "biorxiv"
+    if "medrxiv.org" in url:
+        return "medrxiv"
+    if "doi.org" in url:
+        return "doi"
+    return "unknown"
+
+
+def _write_license_sidecar(pdf_path: Path, url: str, paper: Paper | None) -> None:
+    """Write `<pdf>.license.json` next to a downloaded PDF.
+
+    Captures the URL that produced the bytes, the inferred source, and
+    whatever license/version metadata the upstream API surfaced, so a
+    later "is this PDF safe to share?" check doesn't need the original
+    Paper object. Publisher-API URLs (Elsevier/Wiley/Springer TDM tokens)
+    are explicitly flagged because their terms typically prohibit
+    redistribution of the bytes; the caller decides what to do with that.
+
+    Failure to write the sidecar is logged but never raises -- the PDF
+    itself is the primary artifact.
+    """
+    try:
+        # Try to match the successful URL to a PDFLocation we already have
+        # license/version metadata for; fall back to URL inference otherwise.
+        matched = None
+        if paper is not None:
+            for loc in paper.pdf_locations:
+                if loc.url == url:
+                    matched = loc
+                    break
+
+        if matched is not None:
+            source = matched.source
+            license_value = matched.license
+            version = matched.version
+            is_oa = matched.is_oa
+        else:
+            source = _infer_source_from_url(url)
+            license_value = ""
+            version = ""
+            is_oa = paper.is_oa if paper is not None else False
+
+        publisher_tdm = source.startswith("publisher:")
+
+        sidecar = {
+            "pdf_filename": pdf_path.name,
+            "url": url,
+            "source": source,
+            "license": license_value,
+            "version": version,
+            "is_oa": is_oa,
+            "oa_status": paper.oa_status if paper is not None else "",
+            "publisher_tdm": publisher_tdm,
+            "doi": paper.doi if paper is not None else "",
+            "retrieved_at": datetime.now(UTC)
+            .isoformat(timespec="seconds")
+            .replace("+00:00", "Z"),
+            "note": (
+                "opencite reports licensing information but does not enforce "
+                "redistribution policy. Consult the publisher's license and "
+                "your local policy before re-sharing the downloaded artifact."
+            ),
+        }
+        sidecar_path = pdf_path.with_suffix(pdf_path.suffix + ".license.json")
+        sidecar_path.write_text(json.dumps(sidecar, indent=2))
+    except OSError as e:
+        logger.warning("Failed to write license sidecar for %s: %s", pdf_path, e)

--- a/tests/test_clients/test_openalex.py
+++ b/tests/test_clients/test_openalex.py
@@ -85,7 +85,7 @@ SAMPLE_WORK = {
     ],
     "cited_by_count": 15000,
     "is_retracted": False,
-    "open_access": {"is_oa": True},
+    "open_access": {"is_oa": True, "oa_status": "gold"},
     "topics": [
         {"display_name": "Protein Structure"},
         {"display_name": "Machine Learning"},
@@ -186,6 +186,26 @@ class TestParseWork:
         client = _make_client()
         paper = client._parse_work(SAMPLE_WORK)
         assert paper.url == "https://doi.org/10.1038/s41586-021-03819-2"
+
+    def test_oa_status_parsed_from_open_access(self):
+        client = _make_client()
+        paper = client._parse_work(SAMPLE_WORK)
+        assert paper.oa_status == "gold"
+
+    def test_oa_status_defaults_to_empty_when_missing(self):
+        """A work without the oa_status key (older payload) yields ""."""
+        client = _make_client()
+        work = {**SAMPLE_WORK, "open_access": {"is_oa": True}}
+        paper = client._parse_work(work)
+        assert paper.oa_status == ""
+
+    def test_oa_status_when_open_access_is_null(self):
+        """OpenAlex returns null for open_access on some records."""
+        client = _make_client()
+        work = {**SAMPLE_WORK, "open_access": None}
+        paper = client._parse_work(work)
+        assert paper.oa_status == ""
+        assert paper.is_oa is False
 
     def test_minimal_work(self):
         """Parse a work with minimal fields."""

--- a/tests/test_license_sidecar.py
+++ b/tests/test_license_sidecar.py
@@ -1,0 +1,122 @@
+"""Tests for the license sidecar written next to downloaded PDFs.
+
+The sidecar reports provenance (URL, source, license, version, oa_status,
+publisher_tdm flag) so a later "is this PDF safe to commit?" check can run
+without the original Paper object. opencite reports; the caller enforces.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from opencite.models import IDSet, Paper, PDFLocation
+from opencite.pdf import _infer_source_from_url, _write_license_sidecar
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestInferSourceFromUrl:
+    def test_elsevier(self):
+        assert _infer_source_from_url("https://api.elsevier.com/x") == (
+            "publisher:elsevier"
+        )
+
+    def test_wiley(self):
+        assert _infer_source_from_url("https://api.wiley.com/x") == (
+            "publisher:wiley"
+        )
+
+    def test_springer(self):
+        assert _infer_source_from_url("https://api.springernature.com/x") == (
+            "publisher:springer"
+        )
+
+    def test_arxiv(self):
+        assert _infer_source_from_url("https://arxiv.org/pdf/1706.03762") == "arxiv"
+
+    def test_pmc(self):
+        assert _infer_source_from_url("https://pmc.ncbi.nlm.nih.gov/PMC42") == "pmc"
+
+    def test_biorxiv(self):
+        assert (
+            _infer_source_from_url("https://www.biorxiv.org/content/foo.full.pdf")
+            == "biorxiv"
+        )
+
+    def test_doi(self):
+        assert _infer_source_from_url("https://doi.org/10.1234/abc") == "doi"
+
+    def test_unknown_url(self):
+        assert _infer_source_from_url("https://example.com/foo.pdf") == "unknown"
+
+
+class TestSidecarWriting:
+    def test_sidecar_matches_known_pdf_location(self, tmp_path: Path):
+        pdf_path = tmp_path / "paper.pdf"
+        pdf_path.write_bytes(b"%PDF-fake")
+        loc = PDFLocation(
+            url="https://example.com/paper.pdf",
+            source="openalex",
+            version="publishedVersion",
+            is_oa=True,
+            license="cc-by",
+        )
+        paper = Paper(
+            title="A paper",
+            ids=IDSet(doi="10.1234/abc"),
+            pdf_locations=[loc],
+            is_oa=True,
+            oa_status="gold",
+        )
+
+        _write_license_sidecar(pdf_path, loc.url, paper)
+
+        sidecar = json.loads((tmp_path / "paper.pdf.license.json").read_text())
+        assert sidecar["url"] == loc.url
+        assert sidecar["source"] == "openalex"
+        assert sidecar["license"] == "cc-by"
+        assert sidecar["version"] == "publishedVersion"
+        assert sidecar["oa_status"] == "gold"
+        assert sidecar["is_oa"] is True
+        assert sidecar["doi"] == "10.1234/abc"
+        assert sidecar["publisher_tdm"] is False
+        assert sidecar["pdf_filename"] == "paper.pdf"
+        assert "retrieved_at" in sidecar
+
+    def test_sidecar_flags_publisher_tdm_when_no_metadata_match(
+        self, tmp_path: Path
+    ):
+        # Publisher-API URLs are synthesized in _collect_urls and are not in
+        # paper.pdf_locations; we fall back to URL inference and must flag
+        # publisher_tdm=True so downstream scanners can detect it.
+        pdf_path = tmp_path / "paper.pdf"
+        pdf_path.write_bytes(b"%PDF-fake")
+        paper = Paper(
+            title="A paper",
+            ids=IDSet(doi="10.1016/j.x"),
+            oa_status="closed",
+        )
+
+        _write_license_sidecar(
+            pdf_path, "https://api.elsevier.com/content/article/doi/10.1016/j.x", paper
+        )
+
+        sidecar = json.loads((tmp_path / "paper.pdf.license.json").read_text())
+        assert sidecar["source"] == "publisher:elsevier"
+        assert sidecar["publisher_tdm"] is True
+        assert sidecar["oa_status"] == "closed"
+
+    def test_sidecar_when_no_paper_metadata(self, tmp_path: Path):
+        pdf_path = tmp_path / "paper.pdf"
+        pdf_path.write_bytes(b"%PDF-fake")
+
+        _write_license_sidecar(pdf_path, "https://arxiv.org/pdf/1706.03762", None)
+
+        sidecar = json.loads((tmp_path / "paper.pdf.license.json").read_text())
+        assert sidecar["source"] == "arxiv"
+        assert sidecar["doi"] == ""
+        assert sidecar["oa_status"] == ""
+        assert sidecar["is_oa"] is False
+        assert sidecar["publisher_tdm"] is False

--- a/tests/test_license_sidecar.py
+++ b/tests/test_license_sidecar.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
+import pytest
+
 from opencite.models import IDSet, Paper, PDFLocation
 from opencite.pdf import _infer_source_from_url, _write_license_sidecar
 
@@ -71,10 +73,11 @@ class TestSidecarWriting:
             oa_status="gold",
         )
 
-        _write_license_sidecar(pdf_path, loc.url, paper)
+        _write_license_sidecar(pdf_path, loc.url, loc.url, paper)
 
         sidecar = json.loads((tmp_path / "paper.pdf.license.json").read_text())
         assert sidecar["url"] == loc.url
+        assert sidecar["final_url"] == loc.url
         assert sidecar["source"] == "openalex"
         assert sidecar["license"] == "cc-by"
         assert sidecar["version"] == "publishedVersion"
@@ -96,23 +99,34 @@ class TestSidecarWriting:
         paper = Paper(
             title="A paper",
             ids=IDSet(doi="10.1016/j.x"),
-            oa_status="closed",
+            is_oa=True,
+            oa_status="gold",
         )
 
-        _write_license_sidecar(
-            pdf_path, "https://api.elsevier.com/content/article/doi/10.1016/j.x", paper
+        publisher_url = (
+            "https://api.elsevier.com/content/article/doi/10.1016/j.x"
         )
+        _write_license_sidecar(pdf_path, publisher_url, publisher_url, paper)
 
         sidecar = json.loads((tmp_path / "paper.pdf.license.json").read_text())
         assert sidecar["source"] == "publisher:elsevier"
         assert sidecar["publisher_tdm"] is True
-        assert sidecar["oa_status"] == "closed"
+        assert sidecar["oa_status"] == "gold"
+        # bytes_is_oa must be False even when paper.is_oa is True: the
+        # publisher-TDM bytes carry redistribution restrictions regardless
+        # of whether the paper has an OA copy elsewhere.
+        assert sidecar["is_oa"] is False
 
     def test_sidecar_when_no_paper_metadata(self, tmp_path: Path):
         pdf_path = tmp_path / "paper.pdf"
         pdf_path.write_bytes(b"%PDF-fake")
 
-        _write_license_sidecar(pdf_path, "https://arxiv.org/pdf/1706.03762", None)
+        _write_license_sidecar(
+            pdf_path,
+            "https://arxiv.org/pdf/1706.03762",
+            "https://arxiv.org/pdf/1706.03762",
+            None,
+        )
 
         sidecar = json.loads((tmp_path / "paper.pdf.license.json").read_text())
         assert sidecar["source"] == "arxiv"
@@ -120,3 +134,117 @@ class TestSidecarWriting:
         assert sidecar["oa_status"] == ""
         assert sidecar["is_oa"] is False
         assert sidecar["publisher_tdm"] is False
+
+    def test_final_url_overrides_inference_when_doi_redirects_to_publisher(
+        self, tmp_path: Path
+    ):
+        """doi.org -> publisher TDM redirect must classify as publisher.
+
+        Without `final_url`, the sidecar would record source='doi' and
+        publisher_tdm=False, defeating the redistribution-risk signal.
+        """
+        pdf_path = tmp_path / "paper.pdf"
+        pdf_path.write_bytes(b"%PDF-fake")
+        paper = Paper(
+            title="A paper",
+            ids=IDSet(doi="10.1016/j.x"),
+            is_oa=True,
+            oa_status="gold",
+        )
+
+        _write_license_sidecar(
+            pdf_path,
+            url="https://doi.org/10.1016/j.x",
+            final_url="https://api.elsevier.com/content/article/doi/10.1016/j.x",
+            paper=paper,
+        )
+
+        sidecar = json.loads((tmp_path / "paper.pdf.license.json").read_text())
+        assert sidecar["url"] == "https://doi.org/10.1016/j.x"
+        assert sidecar["final_url"].startswith("https://api.elsevier.com")
+        assert sidecar["source"] == "publisher:elsevier"
+        assert sidecar["publisher_tdm"] is True
+        assert sidecar["is_oa"] is False
+
+    def test_write_failure_is_swallowed(self, tmp_path: Path, monkeypatch):
+        """Filesystem failures must not raise -- PDF is the primary artifact."""
+        pdf_path = tmp_path / "paper.pdf"
+        pdf_path.write_bytes(b"%PDF-fake")
+
+        # Monkeypatch Path.write_text to simulate a read-only filesystem.
+        from pathlib import Path as _Path
+
+        def boom(*_args, **_kwargs):
+            raise OSError("read-only filesystem")
+
+        monkeypatch.setattr(_Path, "write_text", boom)
+        # Must not raise; absence of exception is the contract.
+        _write_license_sidecar(
+            pdf_path, "https://arxiv.org/pdf/x", "https://arxiv.org/pdf/x", None
+        )
+
+    def test_serialization_failure_is_swallowed(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """json.dumps failures (TypeError/ValueError) also must not raise."""
+        pdf_path = tmp_path / "paper.pdf"
+        pdf_path.write_bytes(b"%PDF-fake")
+
+        import opencite.pdf as pdf_mod
+
+        def bad_dumps(*_args, **_kwargs):
+            raise TypeError("not JSON serializable")
+
+        monkeypatch.setattr(pdf_mod.json, "dumps", bad_dumps)
+        _write_license_sidecar(
+            pdf_path, "https://arxiv.org/pdf/x", "https://arxiv.org/pdf/x", None
+        )
+
+
+class TestDownloadWritesSidecar:
+    """Verify PDFRetriever.download wires the sidecar into the success branch."""
+
+    @pytest.mark.asyncio
+    async def test_download_writes_sidecar_next_to_pdf(
+        self, tmp_path: Path, monkeypatch
+    ):
+        from unittest.mock import AsyncMock
+
+        from opencite.config import Config
+        from opencite.pdf import PDFRetriever
+
+        retriever = PDFRetriever(Config())
+        pdf_url = "https://arxiv.org/pdf/1706.03762"
+        paper = Paper(
+            title="Attention",
+            ids=IDSet(doi="10.48550/arXiv.1706.03762", arxiv_id="1706.03762"),
+            pdf_locations=[
+                PDFLocation(url=pdf_url, source="arxiv", is_oa=True)
+            ],
+            is_oa=True,
+            oa_status="green",
+        )
+
+        async def fake_try_download(_self, url, dest, _failures):
+            dest.write_bytes(b"%PDF-fake")
+            return dest, url
+
+        monkeypatch.setattr(PDFRetriever, "_try_download", fake_try_download)
+        # _collect_urls would try Unpaywall; bypass with a controlled list.
+        retriever._collect_urls = AsyncMock(return_value=[pdf_url])
+
+        result = await retriever.download(
+            "10.48550/arXiv.1706.03762",
+            output_dir=str(tmp_path),
+            paper=paper,
+            filename="attention.pdf",
+        )
+
+        assert result is not None
+        assert result.exists()
+        sidecar_path = result.with_suffix(result.suffix + ".license.json")
+        assert sidecar_path.exists()
+        sidecar = json.loads(sidecar_path.read_text())
+        assert sidecar["url"] == pdf_url
+        assert sidecar["source"] == "arxiv"
+        assert sidecar["oa_status"] == "green"

--- a/tests/test_oa_status.py
+++ b/tests/test_oa_status.py
@@ -61,6 +61,18 @@ class TestJsonFormatterSurfacesOaStatus:
         assert location["version"] == "publishedVersion"
         assert location["is_oa"] is True
 
+    def test_pdf_location_keys_present_even_when_empty(self):
+        """Downstream consumers parse license/version unconditionally;
+        the keys must always be present even when the underlying value is
+        empty so a missing-key check isn't mistaken for license-allowed.
+        """
+        loc = PDFLocation(url="https://example.com/x.pdf", source="openalex")
+        paper = _paper(pdf_locations=[loc])
+        out = json.loads(JsonFormatter().format_single(paper, verbose=True))
+        location = out["pdf_locations"][0]
+        assert location["license"] == ""
+        assert location["version"] == ""
+
 
 class TestCsvFormatterSurfacesOaStatus:
     def test_oa_status_column_present(self):

--- a/tests/test_oa_status.py
+++ b/tests/test_oa_status.py
@@ -1,0 +1,73 @@
+"""Tests for `Paper.oa_status` reporting (model + formatters + merge)."""
+
+from __future__ import annotations
+
+import json
+
+from opencite.dedup import merge_papers
+from opencite.formatters.csv_fmt import CsvFormatter
+from opencite.formatters.json_fmt import JsonFormatter
+from opencite.models import IDSet, Paper, PDFLocation
+
+
+def _paper(**overrides) -> Paper:
+    defaults = {
+        "title": "T",
+        "ids": IDSet(doi="10.1/x"),
+    }
+    defaults.update(overrides)
+    return Paper(**defaults)
+
+
+class TestPaperOaStatusField:
+    def test_default_is_empty_string(self):
+        assert _paper().oa_status == ""
+
+    def test_round_trips_through_constructor(self):
+        for status in ("gold", "hybrid", "green", "bronze", "closed", "diamond"):
+            assert _paper(oa_status=status).oa_status == status
+
+
+class TestMergePreservesOaStatus:
+    def test_existing_status_wins_when_present(self):
+        a = _paper(oa_status="gold")
+        b = _paper(oa_status="hybrid")
+        assert merge_papers(a, b).oa_status == "gold"
+
+    def test_takes_from_new_when_existing_empty(self):
+        a = _paper(oa_status="")
+        b = _paper(oa_status="bronze")
+        assert merge_papers(a, b).oa_status == "bronze"
+
+
+class TestJsonFormatterSurfacesOaStatus:
+    def test_oa_status_in_top_level_output(self):
+        paper = _paper(oa_status="bronze")
+        text = JsonFormatter().format_single(paper)
+        assert json.loads(text)["oa_status"] == "bronze"
+
+    def test_pdf_location_license_and_version_in_verbose(self):
+        loc = PDFLocation(
+            url="https://example.com/x.pdf",
+            source="openalex",
+            version="publishedVersion",
+            license="cc-by",
+            is_oa=True,
+        )
+        paper = _paper(pdf_locations=[loc])
+        out = json.loads(JsonFormatter().format_single(paper, verbose=True))
+        location = out["pdf_locations"][0]
+        assert location["license"] == "cc-by"
+        assert location["version"] == "publishedVersion"
+        assert location["is_oa"] is True
+
+
+class TestCsvFormatterSurfacesOaStatus:
+    def test_oa_status_column_present(self):
+        paper = _paper(oa_status="green")
+        out = CsvFormatter().format_single(paper)
+        # First row is header, second is the data row.
+        header, row = out.splitlines()
+        assert "oa_status" in header.split(",")
+        idx = header.split(",").index("oa_status")
+        assert row.split(",")[idx] == "green"


### PR DESCRIPTION
Addresses #35. Reporting-only scope per maintainer feedback: opencite surfaces enough license and OA-status information for downstream pipelines to make their own redistribution decisions, but does not filter, reorder, or refuse downloads. The publication-vs-reuse decision belongs to the caller.

## What we report

### `Paper.oa_status` (str)
OpenAlex Open Access enum: `gold`, `hybrid`, `green`, `bronze`, `closed`, `diamond`, or `""` when unknown.

`is_oa` (bool) collapses gold/hybrid/green/bronze together; `oa_status` distinguishes them. Notably, **bronze** is free-to-read but not openly licensed and is invisible at the boolean level. Parsed in `clients/openalex.py` from `work["open_access"]["oa_status"]`; preserved through `dedup.merge_papers`.

Surfaced in:
- `Paper` model (new field)
- JSON formatter top-level
- CSV formatter (new column)

### `PDFLocation` license/version
Already populated by the OpenAlex client; now surfaced per location in the JSON formatter's verbose output (was previously collapsed to just `url`/`source`/`is_oa`).

### `<pdf>.license.json` sidecar
Written next to every successful PDF download. Schema:

```json
{
  "pdf_filename": "vaswani-2017-attention.pdf",
  "url": "https://...",
  "source": "openalex",
  "license": "cc-by",
  "version": "publishedVersion",
  "is_oa": true,
  "oa_status": "gold",
  "publisher_tdm": false,
  "doi": "10.1234/abc",
  "retrieved_at": "2026-05-21T17:30:00Z",
  "note": "opencite reports licensing information but does not enforce ..."
}
```

A later \"is this PDF safe to commit?\" check can scan sidecars without the original `Paper` object. Source label is matched against `paper.pdf_locations` when possible and inferred from URL pattern otherwise (Elsevier/Wiley/Springer URLs get `publisher_tdm: true` so downstream scanners can detect TDM-acquired bytes).

Sidecar write failures log a warning but don't fail the download -- the PDF is the primary artifact.

## Not implemented (deliberately)

Per maintainer feedback on the issue: \"we should report the OA status, but can't enforce it, it is up to the user to enforce that. We as default save the pdf and markdown however they want to treat that, they do that.\"

- No `--no-tdm` flag
- No `--license-allow` filter
- No reordering of publisher-vs-OA URL priority

These belong on the caller side, where pipeline-specific policy lives.

## Test plan

- [x] 18 new tests across `test_oa_status.py` (model, dedup, JSON, CSV) and `test_license_sidecar.py` (URL inference + sidecar contents for matched-PDFLocation, publisher-fallback, and no-paper cases)
- [x] All 655 unit tests pass on 3.13
- [x] `ruff check` clean
- [x] README updated with a \"Redistribution and licensing\" section that names the OA categories and flags the publisher-TDM redistribution concern