### PR TITLE
fix(search): cancel pending source tasks on cancellation/timeout

### DIFF
--- a/src/opencite/search.py
+++ b/src/opencite/search.py
@@ -162,14 +162,26 @@ class SearchOrchestrator:
         all_papers: list[Paper] = []
         source_counts: dict[str, int] = {}
 
-        for source_name, task in tasks.items():
-            try:
-                papers = await task
-                source_counts[source_name] = len(papers)
-                all_papers.extend(papers)
-            except Exception as exc:
-                logger.warning("Search failed for source %s: %s", source_name, exc)
-                source_counts[source_name] = 0
+        try:
+            for source_name, task in tasks.items():
+                try:
+                    papers = await task
+                    source_counts[source_name] = len(papers)
+                    all_papers.extend(papers)
+                except Exception as exc:
+                    logger.warning("Search failed for source %s: %s", source_name, exc)
+                    source_counts[source_name] = 0
+        finally:
+            # Make sure no per-source task outlives this call. If the caller
+            # cancels search() (e.g. via asyncio.wait_for) part-way through the
+            # loop, the tasks not yet awaited would keep running and then hit
+            # HTTP clients that __aexit__ has already closed. Cancel and drain
+            # whatever is still pending.
+            pending = [t for t in tasks.values() if not t.done()]
+            for task in pending:
+                task.cancel()
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
 
         # Deduplicate and merge
         total_before = len(all_papers)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -250,3 +250,37 @@ class TestEnrichPreprintBranches:
         orchestrator._osf.lookup_doi.assert_not_called()
         orchestrator._zenodo.lookup_doi.assert_not_called()
         orchestrator._figshare.lookup_doi.assert_not_called()
+
+
+class TestSearchCancellation:
+    """search() must not leave per-source tasks running after cancellation."""
+
+    @pytest.mark.asyncio
+    async def test_pending_tasks_cancelled_on_timeout(self):
+        import asyncio
+        from unittest.mock import AsyncMock
+
+        orch = SearchOrchestrator(Config())
+        started: list[asyncio.Task] = []
+
+        async def slow_source(*_args, **_kwargs):
+            started.append(asyncio.current_task())
+            await asyncio.sleep(5)
+            return []
+
+        # Two sources that never finish within the timeout window.
+        orch._search_openalex = AsyncMock(side_effect=slow_source)
+        orch._search_s2 = AsyncMock(side_effect=slow_source)
+
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(
+                orch.search("anything", sources=("openalex", "s2")),
+                timeout=0.1,
+            )
+
+        # Both per-source tasks started; by the time wait_for returns, search()'s
+        # cleanup must have cancelled them. Without the cleanup the un-awaited
+        # second task would still be running here.
+        assert len(started) == 2
+        assert all(t.done() for t in started)
+        assert all(t.cancelled() for t in started)


### PR DESCRIPTION
## Problem (#40)

`SearchOrchestrator.search()` schedules one `asyncio.create_task()` per source, then awaits them in a loop. If the caller cancels `search()` part-way through (e.g. by wrapping it in `asyncio.wait_for(...)` that times out), the cancellation propagates to the task currently being awaited, but the **tasks not yet awaited keep running**. The surrounding `async with SearchOrchestrator(...)` then runs `__aexit__` and closes all the HTTP clients, so those still-running tasks hit closed clients and raise — producing spurious ERROR logs on every timeout. (No leak under `asyncio.run`, but noisy and confusing.)

## Fix

Wrap the await loop in `try/finally`; in `finally`, cancel and `gather(..., return_exceptions=True)` any task that is not yet done. So whether `search()` completes, errors, or is cancelled, no per-source task outlives the call.

Deliberately **not** `asyncio.TaskGroup`: the current design tolerates per-source failures (one source erroring does not abort the others), and a TaskGroup would cancel all siblings on the first exception. The `try/finally` preserves that fault tolerance.

## Test

Added `TestSearchCancellation.test_pending_tasks_cancelled_on_timeout`: patches two sources to be slow, runs `search()` under a 0.1s `wait_for`, and asserts both per-source tasks end up cancelled. Verified it **fails without the fix** (the un-awaited task is still running) and passes with it. Full offline search suite + ruff green.

Found while integrating opencite into Open Science Assistant's live paper-search tool.