### PR TITLE
test(cli): stabilize flaky json-format integration test

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -551,6 +551,10 @@ class TestCLIIntegration:
         assert len(result.stdout.strip()) > 0
 
     def test_search_json_format(self):
+        # Restrict to a single fast source: this test exercises the JSON
+        # formatter, not multi-source fan-out. The default "all sources"
+        # search awaits ~11 public APIs sequentially, so a broad term could
+        # blow past the subprocess timeout on a slow upstream.
         result = subprocess.run(
             [
                 sys.executable,
@@ -560,6 +564,8 @@ class TestCLIIntegration:
                 "transformer",
                 "--max",
                 "3",
+                "--source",
+                "openalex",
                 "-f",
                 "json",
             ],


### PR DESCRIPTION
## Problem

The `integration-test` job on `main` failed after #41 merged:

```
FAILED tests/test_cli.py::TestCLIIntegration::test_search_json_format -
subprocess.TimeoutExpired: '... opencite search transformer --max 3 -f json' timed out after 60 seconds
```

This is **not a #41 regression** — the `finally` block added in #41 is a no-op on the happy path (it only cancels tasks that are still pending after a `wait_for` cancellation). The failure is pre-existing test fragility that surfaced on a slow-network run.

## Root cause

`opencite search transformer` with no `--source` flag defaults to `sources=None` -> `ALL_SOURCES` (~11 public APIs). `SearchOrchestrator.search()` awaits each source task sequentially, so the slowest upstream gates the whole call. With the extremely broad term "transformer", a single slow source (OSF/Zenodo/CORE/CrossRef/etc.) pushes the total past the test's 60s subprocess cap. The job is `continue-on-error: true`, so the overall run still reports success, but the red job is noise.

## Fix

Restrict the query to `--source openalex`, mirroring the reliable sibling `test_search_openalex`. This test exists to verify the `-f json` formatter end-to-end, not multi-source fan-out. Deterministic and fast now.

## Verification

- `test_search_json_format` runs in **~1.1s** locally (was timing out at 60s).
- `ruff check` clean.