### PR TITLE
docs: MkDocs Material site with API reference, deployed to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,58 @@
+name: Documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'src/**'
+      - 'pyproject.toml'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; cancel in-progress runs for the same ref.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # git-revision-date-localized needs full history
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install docs dependencies
+        run: uv sync --group docs
+
+      - name: Build site (strict)
+        run: uv run mkdocs build --strict
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ coverage.xml
 .ruff_cache/
 .mypy_cache/
 
+# Documentation
+site/
+
 # Environment
 .env
 .env.local

--- a/docs/api/citations.md
+++ b/docs/api/citations.md
@@ -1,0 +1,18 @@
+# Citations
+
+`CitationExplorer` traverses the citation graph around a paper: the papers that
+cite it, the papers it references, and the canonical (most-cited) papers in a
+field. It is an async context manager and returns
+[`CitationResult`](models.md) objects.
+
+```python
+from opencite import Config
+from opencite.citations import CitationExplorer
+
+async with CitationExplorer(Config.from_env()) as explorer:
+    citing = await explorer.citing_papers("10.1038/nature12345", max_results=20)
+    refs = await explorer.references("10.1038/nature12345")
+    landmarks = await explorer.canonical_papers("deep learning", min_citations=5000)
+```
+
+::: opencite.citations.CitationExplorer

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -1,0 +1,16 @@
+# Config
+
+`Config` resolves settings from `~/.opencite/config.toml`, `.env` files, and
+environment variables, merging them with environment variables taking
+precedence. Build one with `Config.from_env()` and pass it to an orchestrator.
+
+```python
+from opencite import Config
+
+config = Config.from_env()
+```
+
+See the [Configuration guide](../guides/configuration.md) for the precedence
+rules and the keys OpenCite reads.
+
+::: opencite.config.Config

--- a/docs/api/exceptions.md
+++ b/docs/api/exceptions.md
@@ -1,0 +1,20 @@
+# Exceptions
+
+OpenCite raises a small hierarchy of exceptions, all rooted at
+`OpenCiteError`. Catch the base class to handle any OpenCite-specific failure,
+or a specific subclass for finer control.
+
+```python
+from opencite.exceptions import OpenCiteError, APIKeyError, RateLimitError
+
+try:
+    ...
+except APIKeyError:
+    ...        # missing or invalid API key
+except RateLimitError:
+    ...        # upstream rate limit hit
+except OpenCiteError:
+    ...        # any other OpenCite error
+```
+
+::: opencite.exceptions

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,61 @@
+# API Reference
+
+OpenCite is a library as well as a CLI. The programmatic surface centers on two
+async orchestrators and a set of data models, all configured by a single
+`Config` object.
+
+## At a glance
+
+| Symbol | Module | Use it for |
+| --- | --- | --- |
+| [`SearchOrchestrator`](search.md) | `opencite.search` | Parallel multi-source search with dedup/merge |
+| [`CitationExplorer`](citations.md) | `opencite.citations` | Citation-graph traversal and canonical papers |
+| [`Config`](config.md) | `opencite.config` | Load and merge configuration |
+| [`Paper`, `IDSet`, ...](models.md) | `opencite.models` | Data models returned by the orchestrators |
+| [`OpenCiteError`, ...](exceptions.md) | `opencite.exceptions` | Error hierarchy to catch |
+
+## Typical usage
+
+Both orchestrators are async context managers. Open one, run your queries, and
+let the `async with` block close the underlying HTTP clients:
+
+```python
+import asyncio
+from opencite import Config
+from opencite.search import SearchOrchestrator
+
+
+async def main():
+    config = Config.from_env()
+    async with SearchOrchestrator(config) as searcher:
+        result = await searcher.search(
+            "transformer attention",
+            max_results=10,
+            sources=("openalex", "s2"),
+            sort="citations",
+        )
+        print(f"{len(result.papers)} papers, by source: {result.total_by_source}")
+        for paper in result.papers:
+            print(paper.year, paper.title)
+
+
+asyncio.run(main())
+```
+
+## Top-level exports
+
+The package re-exports the data models and `Config` for convenience:
+
+::: opencite
+    options:
+      members:
+        - Config
+        - Paper
+        - Author
+        - IDSet
+        - Source
+        - PDFLocation
+        - SearchResult
+        - CitationResult
+      show_root_heading: false
+      show_source: false

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -1,0 +1,17 @@
+# Models
+
+The data models returned throughout OpenCite. `Paper` is the central record;
+`IDSet` is the frozen, immutable bundle of identifiers that makes cross-API
+lookup and deduplication possible.
+
+::: opencite.models
+    options:
+      members:
+        - Paper
+        - Author
+        - IDSet
+        - Source
+        - PDFLocation
+        - SearchResult
+        - CitationResult
+        - parse_identifier

--- a/docs/api/search.md
+++ b/docs/api/search.md
@@ -1,0 +1,15 @@
+# Search
+
+`SearchOrchestrator` runs a keyword search across every configured source in
+parallel, then deduplicates and merges the results into a single
+[`SearchResult`](models.md). It is an async context manager.
+
+```python
+from opencite import Config
+from opencite.search import SearchOrchestrator
+
+async with SearchOrchestrator(Config.from_env()) as searcher:
+    result = await searcher.search("graph neural networks", max_results=20)
+```
+
+::: opencite.search.SearchOrchestrator

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -1,0 +1,200 @@
+# CLI Reference
+
+Every OpenCite command and its options. Run `opencite --help` or
+`opencite <command> --help` at any time for the authoritative, version-specific
+listing.
+
+## Global options
+
+```text
+opencite [--version] [--quiet] [--debug] <command> ...
+```
+
+- `--version`: print the installed version and exit.
+- `--quiet`: suppress progress messages.
+- `--debug`: enable debug logging.
+
+| Command | Purpose |
+| --- | --- |
+| [`search`](#search) | Search for papers by keywords |
+| [`lookup`](#lookup) | Look up papers by DOI, PMID, or other ID |
+| [`cite`](#cite) | Citation graph: papers citing or cited by a paper |
+| [`canonical`](#canonical) | Most-cited papers in a field |
+| [`pdf`](#pdf) | Download a PDF for a paper |
+| [`convert`](#convert) | Convert a PDF to markdown |
+| [`ids`](#ids) | Convert between PMID, PMCID, and DOI |
+| [`batch-fetch`](#batch-fetch) | Download PDFs for multiple papers |
+| [`config`](#config) | Manage configuration |
+
+---
+
+## search
+
+Find papers by keywords across all sources, deduplicated and merged.
+
+```bash
+opencite search "query" [--max N] [--source all|openalex|s2|pubmed|...]
+    [--year-from YYYY] [--year-to YYYY] [--oa-only]
+    [--sort relevance|citations|year] [-f text|json|bibtex|csv] [-o FILE] [-v]
+```
+
+| Option | Description |
+| --- | --- |
+| `--max N` | Maximum results (after dedup and sort) |
+| `--source` | Restrict to one source; default `all` |
+| `--year-from` / `--year-to` | Publication-year window |
+| `--oa-only` | Open-access papers only |
+| `--sort` | `relevance` (default), `citations`, or `year` |
+| `-f`, `--format` | `text` (default), `json`, `bibtex`, `csv` |
+| `-o`, `--output` | Write to a file instead of stdout |
+| `-v`, `--verbose` | Include extra fields (PDF locations, license, version) |
+
+See [Searching](../guides/searching.md).
+
+---
+
+## lookup
+
+Look up one or more papers by identifier.
+
+```bash
+opencite lookup IDENTIFIER [IDENTIFIER ...] [--enrich] [--append-bib FILE]
+    [-f text|json|bibtex] [-o FILE] [-v]
+```
+
+Accepts a DOI, `pmid:X`, `pmc:X`, `arxiv:X`, a Semantic Scholar ID, or an
+OpenAlex ID. Multiple identifiers are allowed.
+
+| Option | Description |
+| --- | --- |
+| `--enrich` | Fetch from all sources and merge into one record |
+| `--append-bib FILE` | Append the BibTeX entry to an existing `.bib` file |
+| `-f`, `--format` | `text` (default), `json`, `bibtex` |
+| `-o`, `--output` | Write to a file instead of stdout |
+| `-v`, `--verbose` | Include extra fields |
+
+See [Lookup & Citations](../guides/lookup-and-citations.md).
+
+---
+
+## cite
+
+Traverse the citation graph around a paper.
+
+```bash
+opencite cite IDENTIFIER [--direction citing|references|both] [--max N]
+    [--sort citations|year] [--min-citations N] [-f text|json|bibtex] [-o FILE]
+```
+
+| Option | Description |
+| --- | --- |
+| `--direction` | `citing`, `references`, or `both` |
+| `--max N` | Maximum neighbours to return |
+| `--sort` | `citations` or `year` |
+| `--min-citations N` | Keep only neighbours above this citation count |
+| `-f`, `--format` | `text` (default), `json`, `bibtex` |
+| `-o`, `--output` | Write to a file instead of stdout |
+
+---
+
+## canonical
+
+Find the most-cited papers in a field.
+
+```bash
+opencite canonical "topic" [--max N] [--year-from YYYY] [--min-citations N]
+    [-f text|json|bibtex] [-o FILE]
+```
+
+| Option | Description |
+| --- | --- |
+| `--max N` | Maximum results |
+| `--year-from YYYY` | Earliest publication year |
+| `--min-citations N` | Citation-count floor |
+| `-f`, `--format` | `text` (default), `json`, `bibtex` |
+| `-o`, `--output` | Write to a file instead of stdout |
+
+---
+
+## pdf
+
+Download a PDF for a paper. **Requires the `[pdf]` extra.**
+
+```bash
+opencite pdf IDENTIFIER [-o PATH] [--filename NAME] [--convert]
+    [--converter auto|markitdown|mistral]
+```
+
+| Option | Description |
+| --- | --- |
+| `-o`, `--output PATH` | Output file path or directory |
+| `--filename NAME` | Override the output filename |
+| `--convert` | Also write a markdown rendering next to the PDF |
+| `--converter` | `auto` (default), `markitdown`, or `mistral` |
+
+See [PDFs & Conversion](../guides/pdf-and-conversion.md).
+
+---
+
+## convert
+
+Convert a local PDF to markdown. **Requires the `[pdf]` extra.**
+
+```bash
+opencite convert FILE.pdf [-o FILE] [--converter auto|markitdown|mistral]
+    [--extract-images] [--images-dir DIR]
+```
+
+| Option | Description |
+| --- | --- |
+| `-o`, `--output FILE` | Output markdown path |
+| `--converter` | `auto` (default), `markitdown`, or `mistral` |
+| `--extract-images` | Extract figures into an images directory |
+| `--images-dir DIR` | Where to place extracted images |
+
+---
+
+## ids
+
+Convert between DOI, PMID, and PMCID using the NCBI ID Converter API.
+
+```bash
+opencite ids IDENTIFIER [IDENTIFIER ...] [-f text|json]
+```
+
+---
+
+## batch-fetch
+
+Download PDFs for many papers with controlled concurrency. **Requires the
+`[pdf]` extra.**
+
+```bash
+opencite batch-fetch FILE [-o DIR] [--convert] [--concurrency N] [--summary FILE]
+opencite batch-fetch --from-json FILE [options]
+opencite batch-fetch --from-stdin [options]
+```
+
+| Option | Description |
+| --- | --- |
+| `FILE` | Text file with one identifier per line |
+| `--from-json FILE` | JSON array of DOIs or opencite search results |
+| `--from-stdin` | Read identifiers from stdin |
+| `-o`, `--output DIR` | Output directory |
+| `--convert` | Also produce markdown (organized into `pdf/`, `markdown/`, `markdown/img/`) |
+| `--concurrency N` | Number of parallel downloads |
+| `--summary FILE` | Write a machine-readable report |
+
+---
+
+## config
+
+Manage configuration.
+
+```bash
+opencite config init    # create ~/.opencite/config.toml template
+opencite config show    # display resolved config (keys masked)
+opencite config path    # show config file location
+```
+
+See [Configuration](../guides/configuration.md).

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -1,0 +1,64 @@
+# Architecture
+
+OpenCite aggregates results from many academic sources, deduplicates them, and
+presents them as text, JSON, BibTeX, or CSV. It also retrieves PDFs, fetches
+structured full-text, and converts PDFs to markdown.
+
+## Package layout (`src/opencite/`)
+
+| Module | Responsibility |
+| --- | --- |
+| `models.py` | Central data models: `Paper`, `Author`, `IDSet` (frozen), `Source`, `PDFLocation`, `SearchResult`, `CitationResult`, `parse_identifier()` |
+| `config.py` | `Config` dataclass with `from_env()`, TOML config, multi-location `.env` loading, `create_default_config()` |
+| `exceptions.py` | `OpenCiteError` hierarchy: `APIError`, `RateLimitError`, `APIKeyError`, and more |
+| `cli.py` | argparse subcommands: `search`, `lookup`, `cite`, `canonical`, `pdf`, `convert`, `ids`, `batch-fetch`, `config` |
+| `search.py` | `SearchOrchestrator`: parallel multi-source search with dedup/merge |
+| `citations.py` | `CitationExplorer`: citation-graph traversal and canonical paper discovery |
+| `dedup.py` | DOI + fuzzy-title deduplication with paper merging |
+| `clients/` | Per-API async clients with rate limiting (`base.py`, `openalex.py`, `semantic_scholar.py`, `pubmed.py`, `arxiv.py`, ...) |
+| `bibtex.py` | BibTeX fetch (S2 citation styles, DOI negotiation) and generation |
+| `pdf.py` | Multi-source PDF retrieval with publisher-authenticated downloads |
+| `fulltext.py` | `FullTextRetriever`: PMC BioC full-text for OA articles |
+| `pmc_convert.py` | BioC JSON to markdown (sections, figures, tables, references) |
+| `convert.py` | PDF-to-markdown (markitdown, markit-mistral) with image extraction |
+| `batch.py` | Batch PDF download and conversion with controlled concurrency |
+| `formatters/` | Output formatters (text, json, bibtex, csv) |
+| `utils.py` | Title normalization, fuzzy matching, author parsing, abstract reconstruction |
+
+## Key design patterns
+
+- **`IDSet` is frozen.** It centralizes every identifier type (DOI, PMID, PMCID,
+  OpenAlex, S2, arXiv) so cross-API lookup and deduplication have one source of
+  truth.
+- **Provenance.** `Paper.data_sources` records which APIs contributed data to a
+  merged record.
+- **Rate-limited clients.** `BaseClient` provides a token-bucket rate limiter,
+  retry with backoff, and httpx session management. Each source has its own
+  limit (OpenAlex 100 req/s, PubMed 10 req/s, Semantic Scholar 1 req/s, arXiv
+  3 req/s, and so on).
+- **Parallel fan-out, sequential drain.** `SearchOrchestrator.search()` launches
+  one task per source, then awaits them, merges, deduplicates, sorts, and
+  truncates to `max_results`. Pending tasks are always cancelled and drained so
+  none outlives the call.
+- **Full-text shortcuts.** When converting, OpenCite prefers PMC BioC structured
+  full-text for open-access articles (no PDF needed) and HTML full-text for
+  arXiv ar5iv and bioRxiv/medRxiv `.full`.
+- **PDF priority chain.** Publisher APIs (if tokens are configured) -> OpenAlex /
+  S2 PDF locations -> PMC OA -> direct arXiv/bioRxiv URL -> DOI content
+  negotiation.
+- **Config precedence.** TOML < `.env` files < environment variables.
+
+## Source integrations
+
+| Source | Backend | Notes |
+| --- | --- | --- |
+| OpenAlex | `pyalex` | Broadest coverage (250M+ works); best for PDF URLs, filtering, citation counts |
+| Semantic Scholar | httpx REST | TLDR summaries, embeddings, batch 500 IDs, `citationStyles` for BibTeX |
+| PubMed / PMC | NCBI eutils XML | MeSH terms, ID Converter API; PMC BioC for structured full-text |
+| arXiv | Atom v1 API | Search + direct ID lookup; no key; direct PDF |
+| bioRxiv / medRxiv | CrossRef + Content API | Keyword search via CrossRef; DOI lookup via Content API; no key |
+| OSF Preprints | `api.osf.io/v2/preprints/` | PsyArXiv / SocArXiv / EarthArXiv / MetaArXiv; provider recorded as `osf:{provider}` |
+| Zenodo | `zenodo.org/api/records` | Filtered to publication preprints; optional access token |
+| Figshare | `api.figshare.com/v2` | Filtered to preprints; no key |
+| CrossRef | CrossRef REST | DOI metadata and preprint search |
+| CORE | CORE API | Aggregated open access |

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -1,0 +1,55 @@
+# Contributing
+
+Contributions are welcome. This page covers the local workflow and the checks
+that must pass before a pull request is merged.
+
+## Set up
+
+```bash
+git clone https://github.com/neuromechanist/opencite.git
+cd opencite
+uv sync --extra dev          # install the package and dev dependencies
+uv run opencite --version    # verify the CLI works
+```
+
+For PDF-related work, also install the `[pdf]` extra:
+
+```bash
+uv sync --extra dev --extra pdf
+```
+
+## Run the checks
+
+The same checks run in CI. Run them locally before pushing:
+
+```bash
+uv run ruff check src/ tests/      # lint
+uv run ruff format src/ tests/     # format
+uv run pytest -m "not integration" # unit tests (no network)
+```
+
+The repository ships a pre-commit configuration:
+
+```bash
+uv run pre-commit install
+uv run pre-commit run --all-files
+```
+
+## Code style
+
+- Linting and formatting use [ruff](https://docs.astral.sh/ruff/), configured in
+  `pyproject.toml` (line length 88, an `E/W/F/I/B/C4/UP/ARG/SIM/TCH` rule set).
+- Public APIs use Google-style docstrings, which the
+  [API Reference](../api/index.md) renders via mkdocstrings.
+- Type hints are expected on public functions.
+
+## Pull requests
+
+1. Branch from `main`.
+2. Make focused, atomic commits.
+3. Ensure lint, format, and unit tests pass.
+4. Open a PR against `main`; CI runs the unit tests on Python 3.11, 3.12, and
+   3.13, plus an integration job on merge to `main`.
+
+See [Testing](testing.md) for what the integration job covers and which keys it
+needs.

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -1,0 +1,18 @@
+# Development
+
+Want to hack on OpenCite or understand how it fits together? Start here.
+
+- [Architecture](architecture.md): the package layout, key design patterns, and
+  how the sources are integrated.
+- [Contributing](contributing.md): set up a dev environment, run the checks, and
+  open a pull request.
+- [Testing](testing.md): unit tests, integration tests, and what needs API keys.
+
+## Quick setup
+
+```bash
+git clone https://github.com/neuromechanist/opencite.git
+cd opencite
+uv sync --extra dev
+uv run opencite --version
+```

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -1,0 +1,59 @@
+# Testing
+
+OpenCite uses pytest. Tests split into two groups: fast unit tests that run
+offline, and integration tests that hit real APIs.
+
+## Unit tests
+
+The default suite runs without network access and is what CI checks on every
+push and pull request:
+
+```bash
+uv run pytest -m "not integration"
+```
+
+Run a single file or a single test by name:
+
+```bash
+uv run pytest tests/test_models.py -v
+uv run pytest -k "test_doi"
+```
+
+Coverage is reported automatically (configured in `pyproject.toml`):
+
+```bash
+uv run pytest -m "not integration" --cov=opencite --cov-report=term-missing
+```
+
+## Integration tests
+
+Integration tests make real calls to the academic APIs and are marked with the
+`integration` marker. They are **skipped** unless the relevant API keys are
+present in the environment:
+
+```bash
+export SEMANTIC_SCHOLAR_API_KEY=your_key
+export PUBMED_API_KEY=your_key
+export OPENALEX_API_KEY=your_key
+
+uv run pytest -m integration -v
+```
+
+In CI, the integration job runs only on merge to `main` (it is
+`continue-on-error`, so a transient upstream hiccup does not block the build).
+
+!!! tip "Keep network tests deterministic"
+    Integration tests that exercise multi-source search can be slow and flaky
+    because the slowest upstream gates the whole call. When a test only needs to
+    verify formatting or a single code path, restrict it to one fast source
+    (for example `--source openalex`) rather than searching everything.
+
+## Markers
+
+| Marker | Meaning |
+| --- | --- |
+| `integration` | Hits real APIs; needs keys |
+| `slow` | Takes more than ~10 seconds |
+
+Markers are declared in `pyproject.toml` under `[tool.pytest.ini_options]` with
+`--strict-markers`, so an unknown marker is an error.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,109 @@
+# Getting Started
+
+This page takes you from a clean machine to your first search in a few minutes.
+
+## Install
+
+=== "uv (recommended)"
+
+    ```bash
+    uv pip install opencite              # core
+    uv pip install 'opencite[pdf]'       # + PDF download and markdown conversion
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install opencite                 # core
+    pip install 'opencite[pdf]'          # + PDF download and markdown conversion
+    ```
+
+=== "uvx (no install)"
+
+    ```bash
+    uvx opencite --version
+    uvx opencite search "spiking neural networks"
+    ```
+
+The core install keeps dependencies light. Install the `[pdf]` extra when you
+need `opencite pdf`, `opencite convert`, `opencite batch-fetch --convert`, or
+preprint HTML full-text (arXiv ar5iv, bioRxiv/medRxiv `.full`).
+
+## Set up API keys
+
+OpenCite needs keys for the three primary metadata sources. Generate them from
+each provider, then make them available to OpenCite.
+
+```bash
+export SEMANTIC_SCHOLAR_API_KEY=your_key
+export PUBMED_API_KEY=your_key
+export OPENALEX_API_KEY=your_key
+```
+
+!!! note "OpenAlex now requires a key"
+    OpenAlex requires an API key as of February 2026. Searches that include the
+    OpenAlex source will fail without `OPENALEX_API_KEY`.
+
+Prefer a config file? Create one and OpenCite will read it automatically:
+
+```bash
+opencite config init     # writes ~/.opencite/config.toml
+opencite config show     # prints the resolved config with keys masked
+opencite config path     # prints the config file location
+```
+
+See [Configuration](guides/configuration.md) for the full precedence rules,
+publisher tokens, and the optional `MISTRAL_API_KEY` for PDF conversion.
+
+## Your first search
+
+```bash
+opencite search "transformer attention mechanism"
+```
+
+Narrow it down and write BibTeX straight to a file:
+
+```bash
+opencite search "tDCS motor cortex" \
+    --max 20 \
+    --year-from 2020 \
+    --sort citations \
+    -f bibtex \
+    -o refs.bib
+```
+
+## Look up a known paper
+
+```bash
+opencite lookup 10.1038/nature12345
+opencite lookup 10.1038/nature12345 --enrich   # merge data from all sources
+```
+
+Identifiers can be a DOI, `pmid:X`, `pmc:X`, `arxiv:X`, a Semantic Scholar ID,
+or an OpenAlex ID. You can pass several at once.
+
+## Explore citations
+
+```bash
+opencite cite 10.1038/nature12345 --direction citing       # who cites it
+opencite cite 10.1038/nature12345 --direction references   # what it cites
+opencite canonical "deep learning" --min-citations 5000    # field landmarks
+```
+
+## Retrieve a PDF
+
+```bash
+# Requires the [pdf] extra
+opencite pdf 10.1038/nature12345 -o paper.pdf --convert
+```
+
+With `--convert`, OpenCite also writes a markdown rendering next to the PDF
+(using PMC structured full-text when available, otherwise converting the PDF).
+
+## Where to go next
+
+- [Searching](guides/searching.md): sources, filters, sorting, canonical papers.
+- [Lookup & Citations](guides/lookup-and-citations.md): identifiers, enrichment, citation graphs.
+- [PDFs & Conversion](guides/pdf-and-conversion.md): retrieval, conversion, batch downloads.
+- [Output Formats](guides/output-formats.md): text, JSON, BibTeX, CSV.
+- [API Reference](api/index.md): use OpenCite as a Python library.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -1,0 +1,82 @@
+# Configuration
+
+OpenCite reads configuration from a TOML file, `.env` files, and environment
+variables. You can mix all three; later sources override earlier ones.
+
+## Quick commands
+
+```bash
+opencite config init     # create ~/.opencite/config.toml from a template
+opencite config show     # print the resolved config (secrets masked)
+opencite config path     # print the config file location
+```
+
+## Loading priority
+
+Sources are merged in this order, with later entries winning:
+
+1. `~/.opencite/config.toml`
+2. `~/.opencite/.env`
+3. `.env` in the current working directory
+4. Environment variables
+
+So an environment variable always overrides a value in `config.toml`, which
+makes it easy to keep defaults in the file and override per shell session.
+
+## API keys
+
+Required for the three primary metadata sources:
+
+```bash
+export SEMANTIC_SCHOLAR_API_KEY=your_key
+export PUBMED_API_KEY=your_key
+export OPENALEX_API_KEY=your_key
+```
+
+!!! note "OpenAlex now requires a key"
+    OpenAlex requires an API key as of February 2026. Searches that include the
+    OpenAlex source fail without `OPENALEX_API_KEY`.
+
+Optional, for PDF-to-markdown conversion via Mistral OCR:
+
+```bash
+export MISTRAL_API_KEY=your_key
+```
+
+## Publisher tokens (optional)
+
+For authenticated PDF downloads from paywalled publishers:
+
+```bash
+export ELSEVIER_API_KEY=your_key       # Elsevier / ScienceDirect
+export WILEY_TDM_TOKEN=your_token      # Wiley TDM
+export SPRINGER_API_KEY=your_key       # Springer Nature
+```
+
+The same values can live in `~/.opencite/config.toml`:
+
+```toml
+[publishers]
+elsevier = "your_key"
+wiley_tdm = "your_token"
+springer = "your_key"
+```
+
+!!! warning "Publisher TDM tokens usually prohibit redistribution"
+    Tokens for Elsevier, Wiley, and Springer almost always forbid
+    redistributing the bytes they return. OpenCite records a
+    `publisher_tdm: true` flag in each PDF's license sidecar so downstream
+    scanners can detect this. See [Redistribution & Licensing](licensing.md).
+
+## Using config from Python
+
+[`Config`](../api/config.md) exposes the same resolution logic:
+
+```python
+from opencite import Config
+
+config = Config.from_env()       # TOML + .env + environment, merged
+```
+
+Pass that `config` to [`SearchOrchestrator`](../api/search.md) or
+[`CitationExplorer`](../api/citations.md).

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,0 +1,38 @@
+# Guides
+
+Task-focused recipes for getting real work done with OpenCite. Each guide
+assumes you have installed OpenCite and set up your API keys (see
+[Getting Started](../getting-started.md)).
+
+<div class="grid cards" markdown>
+
+-   :material-magnify: __[Searching](searching.md)__
+
+    Choose sources, filter by year and open access, sort by relevance,
+    citations, or year, and surface the canonical papers in a field.
+
+-   :material-link-variant: __[Lookup & Citations](lookup-and-citations.md)__
+
+    Resolve identifiers, enrich a paper across sources, and walk citation
+    graphs forward and backward.
+
+-   :material-file-pdf-box: __[PDFs & Conversion](pdf-and-conversion.md)__
+
+    Retrieve PDFs, convert them to markdown, and download in batch with
+    controlled concurrency.
+
+-   :material-cog: __[Configuration](configuration.md)__
+
+    Config files, environment variables, API keys, and publisher tokens, with
+    the exact precedence rules.
+
+-   :material-format-list-bulleted: __[Output Formats](output-formats.md)__
+
+    Text, JSON, BibTeX, and CSV, and when to use each.
+
+-   :material-scale-balance: __[Redistribution & Licensing](licensing.md)__
+
+    What OpenCite reports about open-access status and licensing, and what that
+    means for pipelines that publish artifacts.
+
+</div>

--- a/docs/guides/licensing.md
+++ b/docs/guides/licensing.md
@@ -1,0 +1,66 @@
+# Redistribution & Licensing
+
+OpenCite retrieves PDFs and markdown for you and **reports** what it found, but
+it does not enforce a redistribution policy. The publication-versus-reuse
+decision belongs to you, the caller. This page explains what OpenCite reports so
+you can make that decision deliberately.
+
+## What OpenCite reports
+
+### Open-access status
+
+[`Paper.oa_status`](../api/models.md) carries the OpenAlex Open Access status:
+
+- `gold`, `hybrid`, `green`, `bronze`, `closed`, `diamond`, or empty (unknown).
+- `is_oa = True` collapses all open categories together; `oa_status`
+  distinguishes them.
+
+!!! warning "Bronze is free-to-read, not openly licensed"
+    A `bronze` paper can be read for free on the publisher site but is **not**
+    released under an open license. Free to read does not mean free to
+    redistribute.
+
+### Per-source license and version
+
+[`PDFLocation.license`](../api/models.md) and `PDFLocation.version` record, where
+the upstream API surfaces them:
+
+- the license string (`cc-by`, `cc-by-nc`, ...)
+- the version (`publishedVersion`, `acceptedVersion`, `submittedVersion`)
+
+These are visible in `opencite lookup --format json --verbose` and in
+`opencite search` output.
+
+### The license sidecar
+
+Every downloaded PDF gets a `<pdf>.license.json` sidecar written next to it,
+containing:
+
+```json
+{
+  "url": "...",
+  "source": "...",
+  "license": "cc-by",
+  "version": "publishedVersion",
+  "oa_status": "gold",
+  "publisher_tdm": false,
+  "doi": "10.1038/nature12345",
+  "retrieved_at": "..."
+}
+```
+
+A later "is this PDF safe to commit?" check can scan the sidecars without
+re-querying the original metadata.
+
+## Guidance for pipelines that publish artifacts
+
+If your pipeline commits PDFs or markdown to a public repository, be deliberate
+about which sources you enable.
+
+- Publisher TDM tokens (Elsevier, Wiley, Springer) almost universally **prohibit
+  redistribution** of the bytes they return.
+- The sidecar's `publisher_tdm: true` flag is a machine-readable signal that a
+  downstream scanner can use to block such files from being published.
+
+When in doubt, prefer `gold`/`diamond`/`cc-by` sources for anything you intend
+to redistribute, and treat `bronze` and publisher-TDM content as read-only.

--- a/docs/guides/lookup-and-citations.md
+++ b/docs/guides/lookup-and-citations.md
@@ -1,0 +1,105 @@
+# Lookup & Citations
+
+Beyond keyword search, OpenCite resolves specific papers by identifier and walks
+the citation graph around them.
+
+## Look up by identifier
+
+```bash
+opencite lookup 10.1038/nature12345
+```
+
+OpenCite auto-detects the identifier type. Accepted forms:
+
+- a DOI (e.g. `10.1038/nature12345`)
+- `pmid:NNNN` (PubMed ID)
+- `pmc:NNNN` (PubMed Central ID)
+- `arxiv:NNNN.NNNNN` (arXiv ID)
+- a Semantic Scholar paper ID
+- an OpenAlex work ID
+
+Look up several at once:
+
+```bash
+opencite lookup 10.1038/nature12345 pmid:34265844 arxiv:1706.03762
+```
+
+### Enrich across sources
+
+By default `lookup` resolves the identifier from the most appropriate single
+source. Add `--enrich` to fetch from every API and merge the results into one
+richer record (more identifiers, abstract, citation counts, PDF locations):
+
+```bash
+opencite lookup 10.1038/nature12345 --enrich
+```
+
+### Append to a BibTeX library
+
+```bash
+opencite lookup 10.1038/nature12345 --append-bib refs.bib
+```
+
+This fetches the entry and appends it to an existing `.bib` file, so you can
+build a reference library one paper at a time.
+
+## Citation graphs
+
+The `cite` command traverses citations around a paper.
+
+```bash
+# Papers that cite this work
+opencite cite 10.1038/nature12345 --direction citing
+
+# Papers this work cites (its references)
+opencite cite 10.1038/nature12345 --direction references
+
+# Both directions
+opencite cite 10.1038/nature12345 --direction both
+```
+
+Refine the traversal:
+
+```bash
+opencite cite 10.1038/nature12345 \
+    --direction citing \
+    --max 50 \
+    --sort citations \
+    --min-citations 100
+```
+
+- `--max N`: cap the number of returned papers.
+- `--sort citations|year`: order the neighbours.
+- `--min-citations N`: keep only well-cited neighbours, useful for finding the
+  influential descendants of a seminal paper.
+
+## Convert between identifiers
+
+When you only need to translate identifiers (not full records), `ids` uses the
+NCBI ID Converter API to map between DOI, PMID, and PMCID:
+
+```bash
+opencite ids 34265844
+opencite ids PMC8341181 10.1038/nature12345 -f json
+```
+
+## Use it from Python
+
+The same traversals are available programmatically through
+[`CitationExplorer`](../api/citations.md):
+
+```python
+import asyncio
+from opencite import Config
+from opencite.citations import CitationExplorer
+
+
+async def main():
+    async with CitationExplorer(Config.from_env()) as explorer:
+        result = await explorer.citing_papers("10.1038/nature12345", max_results=20)
+        for paper in result.papers:
+            print(paper.citation_count, paper.title)
+
+
+asyncio.run(main())
+```

--- a/docs/guides/output-formats.md
+++ b/docs/guides/output-formats.md
@@ -1,0 +1,72 @@
+# Output Formats
+
+The `search`, `lookup`, `cite`, and `canonical` commands all share the same
+output controls: `-f`/`--format` chooses the shape, and `-o`/`--output` writes to
+a file instead of stdout.
+
+## Formats
+
+| Format | Flag | Best for | Available in |
+| --- | --- | --- | --- |
+| Text | `-f text` (default) | Reading in the terminal | all commands |
+| JSON | `-f json` | Piping into other tools, batch downloads | all commands |
+| BibTeX | `-f bibtex` | Reference managers, LaTeX | all commands |
+| CSV | `-f csv` | Spreadsheets | `search` only |
+
+## Text
+
+The default. Human-readable, one paper per block, with title, authors, year,
+venue, and identifiers.
+
+```bash
+opencite search "graph neural networks"
+```
+
+## JSON
+
+Structured output, ideal as machine input. The JSON from a `search` is the
+natural input for [batch downloads](pdf-and-conversion.md#batch-downloads):
+
+```bash
+opencite search "graph neural networks" --max 50 -f json -o gnn.json
+opencite batch-fetch --from-json gnn.json --convert -o ./papers
+```
+
+Add `-v`/`--verbose` to include extra fields such as per-source PDF locations,
+license, and version where the upstream APIs surface them.
+
+## BibTeX
+
+Citation entries ready for your reference manager or LaTeX bibliography:
+
+```bash
+opencite search "graph neural networks" --max 20 -f bibtex -o gnn.bib
+```
+
+`lookup` can also append to an existing library in one step:
+
+```bash
+opencite lookup 10.1038/nature12345 --append-bib refs.bib
+```
+
+## CSV
+
+A flat, spreadsheet-friendly table. Available for `search`:
+
+```bash
+opencite search "graph neural networks" --max 100 -f csv -o gnn.csv
+```
+
+## Writing to a file
+
+Every format respects `-o`/`--output`:
+
+```bash
+opencite canonical "reinforcement learning" --min-citations 2000 -f bibtex -o rl.bib
+```
+
+Without `-o`, output goes to stdout, so you can pipe it:
+
+```bash
+opencite search "transformers" -f json | jq '.[].title'
+```

--- a/docs/guides/pdf-and-conversion.md
+++ b/docs/guides/pdf-and-conversion.md
@@ -1,0 +1,97 @@
+# PDFs & Conversion
+
+OpenCite can retrieve PDFs, convert them to markdown, and download many papers
+at once.
+
+!!! warning "Requires the `[pdf]` extra"
+    PDF retrieval and conversion depend on extra packages. Install them with
+    `pip install 'opencite[pdf]'` (or `uv pip install 'opencite[pdf]'`). This
+    extra also powers preprint HTML full-text shortcuts (arXiv ar5iv,
+    bioRxiv/medRxiv `.full`).
+
+## Download a single PDF
+
+```bash
+opencite pdf 10.1038/nature12345 -o paper.pdf
+```
+
+`-o` accepts either a file path (`paper.pdf`) or a directory. OpenCite tries
+sources in priority order:
+
+1. Publisher APIs (when you have configured publisher tokens)
+2. OpenAlex / Semantic Scholar PDF locations
+3. PMC open-access
+4. Direct arXiv / bioRxiv URLs
+5. DOI content negotiation
+
+### Convert to markdown at the same time
+
+```bash
+opencite pdf 10.1038/nature12345 -o paper.pdf --convert
+```
+
+With `--convert`, OpenCite also writes a markdown file next to the PDF. When the
+paper is in the PMC open-access subset, it uses the PMC BioC structured
+full-text (sections, figures, tables, references) instead of converting the PDF,
+which produces cleaner markdown.
+
+Pick a converter explicitly:
+
+```bash
+opencite pdf 10.1038/nature12345 --convert --converter mistral
+```
+
+- `auto` (default): use markit-mistral when `MISTRAL_API_KEY` is set (better for
+  math and complex layouts), otherwise fall back to markitdown (free, local).
+- `markitdown`: always use the free local converter.
+- `mistral`: always use markit-mistral (requires `MISTRAL_API_KEY`).
+
+## Convert a PDF you already have
+
+```bash
+opencite convert paper.pdf -o paper.md
+opencite convert paper.pdf --extract-images --images-dir ./img
+```
+
+The same `--converter auto|markitdown|mistral` choice applies. `--extract-images`
+pulls figures out into an images directory.
+
+## Batch downloads
+
+Download PDFs for many papers with controlled concurrency. `batch-fetch` reads
+from a text file (one identifier per line), a JSON file, or stdin.
+
+```bash
+# One DOI per line
+opencite batch-fetch dois.txt -o ./papers --convert
+
+# From a saved search (JSON array of results or DOIs)
+opencite batch-fetch --from-json results.json --convert -o ./papers
+
+# From stdin
+cat dois.txt | opencite batch-fetch --from-stdin -o ./papers
+```
+
+Useful options:
+
+- `--concurrency N`: how many downloads run in parallel.
+- `--summary report.json`: write a machine-readable report of what succeeded.
+- `--convert`: also produce markdown; output is organized into `pdf/`,
+  `markdown/`, and `markdown/img/` subdirectories.
+
+### A complete workflow
+
+Search, save as JSON, then batch download and convert:
+
+```bash
+opencite search "tDCS motor cortex" --max 30 -f json -o results.json
+opencite batch-fetch --from-json results.json \
+    --convert \
+    --summary report.json \
+    -o ./papers
+```
+
+!!! note "Be deliberate about redistribution"
+    PDFs you retrieve carry licenses. Before committing downloaded bytes to a
+    public repository, read [Redistribution & Licensing](licensing.md), which
+    explains the per-PDF license sidecar OpenCite writes.

--- a/docs/guides/searching.md
+++ b/docs/guides/searching.md
@@ -1,0 +1,85 @@
+# Searching
+
+The `search` command finds papers by keywords across every configured source,
+deduplicates the results, and returns a single merged list.
+
+## Basic search
+
+```bash
+opencite search "transformer attention mechanism"
+```
+
+By default the search fans out to all available sources concurrently. Each
+source contributes its hits; OpenCite then merges duplicates (DOI match first,
+then fuzzy title match) and tracks which APIs contributed to each paper.
+
+## Choose your sources
+
+Restrict the search to a single source with `--source`:
+
+```bash
+opencite search "AlphaFold protein" --source openalex
+opencite search "EEG microstates" --source pubmed
+```
+
+Restricting sources is the fastest, most deterministic way to search, because
+OpenCite no longer waits on slower upstreams. It is the right choice when you
+know which database has the best coverage for your topic.
+
+| `--source` value | Database |
+| --- | --- |
+| `all` (default) | Every configured source |
+| `openalex` | OpenAlex |
+| `s2` | Semantic Scholar |
+| `pubmed` | PubMed |
+| `arxiv` | arXiv |
+| `biorxiv` | bioRxiv |
+| `medrxiv` | medRxiv |
+| `osf` | OSF Preprints |
+| `zenodo` | Zenodo |
+| `figshare` | Figshare |
+| `crossref` | CrossRef |
+| `core` | CORE |
+
+## Filter and sort
+
+```bash
+opencite search "tDCS motor cortex" \
+    --max 30 \
+    --year-from 2020 \
+    --year-to 2024 \
+    --oa-only \
+    --sort citations
+```
+
+- `--max N`: cap the number of results (applied after dedup and sort).
+- `--year-from` / `--year-to`: restrict to a publication-year window.
+- `--oa-only`: keep only open-access papers.
+- `--sort relevance|citations|year`: order the merged list. `relevance` is the
+  default; `citations` surfaces the most influential work; `year` shows the
+  newest first.
+
+## Canonical papers in a field
+
+When you want the landmark papers rather than the most recent, use `canonical`.
+It searches and ranks by citation count, with a floor you control:
+
+```bash
+opencite canonical "deep learning" --min-citations 5000
+opencite canonical "diffusion models" --max 10 --year-from 2020
+```
+
+- `--min-citations N`: drop papers below this citation count.
+- `--max N` and `--year-from` work as they do for `search`.
+
+## Save results for later
+
+Any search can be written to a file in your format of choice:
+
+```bash
+opencite search "spiking neural networks" --max 50 -f json -o snn.json
+opencite search "spiking neural networks" --max 50 -f bibtex -o snn.bib
+```
+
+The JSON output is the natural input for [batch PDF downloads](pdf-and-conversion.md#batch-downloads).
+See [Output Formats](output-formats.md) for the full list.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,101 @@
+# OpenCite
+
+**Academic literature search, citation management, and PDF retrieval, from one command line.**
+
+OpenCite searches Semantic Scholar, OpenAlex, PubMed, arXiv, bioRxiv, medRxiv,
+OSF Preprints (PsyArXiv / SocArXiv / ...), Zenodo, Figshare, CrossRef, and CORE
+**in parallel**, deduplicates the results, and gives you back clean,
+citation-ready output. It also traverses citation graphs, retrieves PDFs (with
+HTML full-text shortcuts for arXiv ar5iv and bioRxiv `.full`), downloads in
+batch, and converts PDFs to markdown.
+
+```bash
+uv pip install opencite
+export OPENALEX_API_KEY=your_key
+opencite search "transformer attention mechanism"
+```
+
+## Why OpenCite
+
+<div class="grid cards" markdown>
+
+-   :material-magnify-scan: __One query, every source__
+
+    A single search fans out to a dozen academic APIs concurrently, then merges
+    and deduplicates by DOI and fuzzy title match, so you do not chase the same
+    paper across ten tabs.
+
+-   :material-graph-outline: __Citation graphs__
+
+    Walk forward (papers that cite this) or backward (its references), or find
+    the canonical, most-cited papers in a field.
+
+-   :material-file-document-arrow-right-outline: __PDFs to markdown__
+
+    Retrieve open-access PDFs and convert them to markdown, with PMC structured
+    full-text shortcuts and batch downloads at controlled concurrency.
+
+-   :material-format-list-bulleted-type: __Output that fits your workflow__
+
+    Text, JSON, BibTeX, or CSV. Pipe JSON into the next tool, or append BibTeX
+    straight into your reference manager.
+
+</div>
+
+## Two ways to use it
+
+=== "Command line"
+
+    ```bash
+    opencite search "tDCS motor cortex" --max 20 -f bibtex -o refs.bib
+    opencite lookup 10.1038/nature12345 --enrich
+    opencite cite 10.1038/nature12345 --direction citing
+    ```
+
+    See the [CLI Reference](cli/index.md) for every command and flag.
+
+=== "Python library"
+
+    ```python
+    import asyncio
+    from opencite import Config
+    from opencite.search import SearchOrchestrator
+
+
+    async def main():
+        async with SearchOrchestrator(Config.from_env()) as searcher:
+            result = await searcher.search("transformer attention", max_results=10)
+            for paper in result.papers:
+                print(paper.year, paper.title)
+
+
+    asyncio.run(main())
+    ```
+
+    See the [API Reference](api/index.md) for the full programmatic surface.
+
+## Sources
+
+| Source | Coverage | Key required |
+| --- | --- | --- |
+| OpenAlex | 250M+ works; PDF URLs, filters, citation counts | Yes |
+| Semantic Scholar | TLDR summaries, embeddings, BibTeX styles | Yes |
+| PubMed / PMC | MeSH terms, structured OA full-text | Yes |
+| arXiv | Preprints, direct PDF | No |
+| bioRxiv / medRxiv | Life-science preprints | No |
+| OSF Preprints | PsyArXiv, SocArXiv, EarthArXiv, MetaArXiv | No |
+| Zenodo | Publication preprints | No (token optional) |
+| Figshare | Preprints | No |
+| CrossRef | DOI metadata, preprint search | No |
+| CORE | Aggregated open access | No |
+
+## Next steps
+
+- New here? Start with [Getting Started](getting-started.md).
+- Want recipes? Browse the [Guides](guides/index.md).
+- Building on top of it? Read the [API Reference](api/index.md).
+
+!!! tip "AI-agent skill"
+    OpenCite ships as an agent skill in
+    [neuromechanist/research-skills](https://github.com/neuromechanist/research-skills),
+    usable from Claude Code, Codex / OpenAI, and VS Code GitHub Copilot.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,123 @@
+# --- Basic Site Information ---
+site_name: OpenCite
+site_url: https://neuromechanist.github.io/opencite/
+site_description: >-
+  Academic literature search, citation management, and PDF retrieval CLI and
+  Python library. Aggregates Semantic Scholar, OpenAlex, PubMed, arXiv, and more.
+site_author: Seyed Yahya Shirazi
+
+# --- Repository Information ---
+repo_url: https://github.com/neuromechanist/opencite/
+repo_name: neuromechanist/opencite
+edit_uri: edit/main/docs/
+
+# --- Theme Configuration (Material for MkDocs) ---
+theme:
+  name: material
+  icon:
+    logo: material/book-search-outline
+    repo: fontawesome/brands/github
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.indexes
+    - navigation.top
+    - navigation.tracking
+    - navigation.footer
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.code.annotate
+    - content.action.edit
+    - toc.follow
+
+# --- Markdown Extensions ---
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - tables
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.tabbed:
+      alternate_style: true
+  - toc:
+      permalink: true
+      toc_depth: 3
+
+# --- Plugins ---
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [src]
+          options:
+            docstring_style: google
+            show_source: true
+            show_root_heading: true
+            show_root_full_path: false
+            heading_level: 2
+            members_order: source
+            separate_signature: true
+            show_signature_annotations: true
+            signature_crossrefs: true
+            filters: ["!^_"]
+  - git-revision-date-localized:
+      enable_creation_date: true
+      enable_git_follow: false
+      type: date
+
+# --- Navigation Structure ---
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Guides:
+    - guides/index.md
+    - Searching: guides/searching.md
+    - Lookup & Citations: guides/lookup-and-citations.md
+    - PDFs & Conversion: guides/pdf-and-conversion.md
+    - Configuration: guides/configuration.md
+    - Output Formats: guides/output-formats.md
+    - Redistribution & Licensing: guides/licensing.md
+  - CLI Reference: cli/index.md
+  - API Reference:
+    - api/index.md
+    - Search: api/search.md
+    - Citations: api/citations.md
+    - Models: api/models.md
+    - Config: api/config.md
+    - Exceptions: api/exceptions.md
+  - Development:
+    - development/index.md
+    - Architecture: development/architecture.md
+    - Contributing: development/contributing.md
+    - Testing: development/testing.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/neuromechanist/opencite
+    - icon: fontawesome/brands/python
+      link: https://pypi.org/project/opencite/
+
+copyright: Copyright &copy; 2026 Seyed Yahya Shirazi &middot; MIT License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,18 @@ dev = [
 opencite = "opencite.__main__:main"
 
 [project.urls]
+Homepage = "https://neuromechanist.github.io/opencite/"
+Documentation = "https://neuromechanist.github.io/opencite/"
 Repository = "https://github.com/neuromechanist/opencite"
 Issues = "https://github.com/neuromechanist/opencite/issues"
+
+[dependency-groups]
+docs = [
+    "mkdocs-material>=9.5.0",
+    "mkdocstrings[python]>=0.27.0",
+    "mkdocs-git-revision-date-localized-plugin>=1.2.0",
+    "ruff>=0.8.0",  # mkdocstrings uses ruff to format separated signatures
+]
 
 [tool.hatch.version]
 path = "src/opencite/__init__.py"


### PR DESCRIPTION
## What

Adds a complete documentation site for OpenCite, built with MkDocs Material and deployed to GitHub Pages at **https://neuromechanist.github.io/opencite/**.

## Contents

- **Home** + **Getting Started**: install, API keys, first search/lookup/cite/pdf.
- **Guides**: searching, lookup & citations, PDFs & conversion, configuration, output formats, redistribution & licensing.
- **CLI Reference**: every command and flag (derived from the actual `--help` and parser).
- **API Reference**: auto-generated from Google-style docstrings via mkdocstrings, covering `SearchOrchestrator`, `CitationExplorer`, the data models, `Config`, and the exception hierarchy.
- **Development**: architecture, contributing, testing.

## Infrastructure

- `mkdocs.yml`: Material theme (light/dark), mkdocstrings (Python, Google docstrings, ruff-formatted signatures), git-revision-date plugin with `enable_git_follow: false` (avoids the timestamp-ordering warning that trips `--strict`).
- `pyproject.toml`: `docs` dependency group; `Homepage`/`Documentation` URLs.
- `.github/workflows/docs.yml`: build (`mkdocs build --strict`) + deploy via `actions/deploy-pages` on push to `main` (paths: docs, mkdocs.yml, src, pyproject); `workflow_dispatch` enabled.
- `.gitignore`: ignore built `site/`.

## Verification

- `mkdocs build --strict` passes locally with **zero warnings** (exit 0), using the exact CI command.
- All API symbols verified present in the rendered HTML (`SearchOrchestrator.search`, `citing_papers`/`references`/`canonical_papers`, `Paper.oa_status`/`citation_count`, `OpenCiteError`).
- Every code example and attribute was checked against the source (no fabricated APIs).

## One-time setup

GitHub Pages source must be set to **GitHub Actions** (`build_type=workflow`) for the deploy job to publish. Done as part of this change.