### PR TITLE
Add CITATION.cff and Zenodo metadata (v0.5.4)

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,25 @@
+{
+  "title": "OpenCite",
+  "description": "A command-line tool for academic literature search, citation management, and PDF retrieval. Queries Semantic Scholar, OpenAlex, PubMed, arXiv, bioRxiv, medRxiv, OSF Preprints, Zenodo, Figshare, CrossRef, and CORE in parallel, deduplicates results, and supports BibTeX export, citation graph traversal, batch PDF downloads, and PDF-to-markdown conversion.",
+  "upload_type": "software",
+  "access_right": "open",
+  "license": "MIT",
+  "creators": [
+    {
+      "name": "Shirazi, Seyed Yahya",
+      "orcid": "0000-0001-5557-259X",
+      "affiliation": "Swartz Center for Computational Neuroscience, University of California San Diego"
+    }
+  ],
+  "keywords": [
+    "academic",
+    "literature",
+    "search",
+    "citations",
+    "bibtex",
+    "pdf",
+    "pubmed",
+    "openalex",
+    "semantic-scholar"
+  ]
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,34 @@
+cff-version: 1.3.0
+message: "If you use OpenCite in your research, please cite it using the metadata below."
+title: OpenCite
+abstract: >-
+  OpenCite is a command-line tool for academic literature search, citation
+  management, and PDF retrieval. It queries Semantic Scholar, OpenAlex, PubMed,
+  arXiv, bioRxiv, medRxiv, OSF Preprints, Zenodo, Figshare, CrossRef, and CORE in
+  parallel, deduplicates results, and supports BibTeX export, citation graph
+  traversal, batch PDF downloads, and PDF-to-markdown conversion.
+type: software
+authors:
+  - family-names: Shirazi
+    given-names: Seyed Yahya
+    orcid: "https://orcid.org/0000-0001-5557-259X"
+    affiliation:
+      name: "Swartz Center for Computational Neuroscience"
+      ror: "https://ror.org/01bt2qm76"
+repository-code: "https://github.com/neuromechanist/opencite"
+url: "https://neuromechanist.github.io/opencite/"
+license: MIT
+version: 0.5.4
+date-released: "2026-06-14"
+keywords:
+  - academic
+  - literature
+  - search
+  - citations
+  - bibtex
+  - pdf
+  - pubmed
+  - openalex
+  - semantic-scholar
+# Concept (all-versions) DOI is added after the first Zenodo release; it always
+# resolves to the latest version.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,15 @@ uv run ruff check --fix src/ tests/  # auto-fix lint
 uv run ruff format src/ tests/   # format
 ```
 
+## Releases & Citation
+
+The package version is `__version__` in `src/opencite/__init__.py` (Hatch reads it). The
+repository is archived to Zenodo on every GitHub release, minting a versioned DOI under a stable
+concept DOI. When you bump `__version__` for a release, also bump `version` (and `date-released`)
+in `CITATION.cff` and keep `.zenodo.json` in sync, then tag `vX.Y.Z` and create the GitHub
+release. The concept DOI, added to `CITATION.cff` (`doi:`) and the README badge after the first
+Zenodo deposit, is stable across versions.
+
 ## Architecture
 
 ### Package Layout (`src/opencite/`)

--- a/src/opencite/__init__.py
+++ b/src/opencite/__init__.py
@@ -1,6 +1,6 @@
 """opencite: Academic literature search, citation management, and PDF retrieval."""
 
-__version__ = "0.5.3"
+__version__ = "0.5.4"
 
 from .config import Config
 from .models import (

--- a/src/opencite/clients/arxiv.py
+++ b/src/opencite/clients/arxiv.py
@@ -65,6 +65,7 @@ class ArXivClient(PreprintClient):
         max_results: int = 20,
         year_from: int | None = None,
         year_to: int | None = None,
+        **_kwargs: object,
     ) -> list[Paper]:
         """Search arXiv for papers matching *query*.
 

--- a/src/opencite/clients/base.py
+++ b/src/opencite/clients/base.py
@@ -7,7 +7,7 @@ import logging
 import threading
 import time
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, Self
 
 import httpx
 
@@ -119,7 +119,7 @@ class BaseClient(ABC):
         with BaseClient._shared_limiters_lock:
             BaseClient._shared_limiters.clear()
 
-    async def __aenter__(self) -> BaseClient:
+    async def __aenter__(self) -> Self:
         self._client = httpx.AsyncClient(
             base_url=self.base_url,
             timeout=self.timeout,

--- a/src/opencite/convert.py
+++ b/src/opencite/convert.py
@@ -97,13 +97,10 @@ def _convert_with_mistral(
             "Install with: pip install 'opencite[pdf]'"
         ) from e
 
-    kwargs: dict[str, object] = {}
-    if api_key:
-        kwargs["api_key"] = api_key
-    if extract_images:
-        kwargs["include_images"] = True
-
-    converter = MarkItMistral(**kwargs)
+    converter = MarkItMistral(
+        api_key=api_key or None,
+        include_images=extract_images or None,
+    )
 
     if extract_images and output_path:
         # Use convert_file for full output with images


### PR DESCRIPTION
Adds `CITATION.cff` (CFF 1.3.0, structured affiliation with ROR) and `.zenodo.json` so GitHub releases are archived to Zenodo with a citable DOI. Bumps `__version__` to 0.5.4. CLAUDE.md documents the release rule: bump `CITATION.cff` `version`/`date-released` in sync with `__version__`, keep `.zenodo.json` aligned.

Also fixes 3 pre-existing `ty` type errors that the pre-commit hook flagged (separate first commit):
- `BaseClient.__aenter__` now returns `Self` so context-managed subclients keep their concrete type (resolves `converter.convert` on `IDConverterClient`)
- `ArXivClient.search` accepts `**_kwargs` to match the `PreprintClient.search` contract (Liskov-compatible)
- `_convert_with_mistral` constructs `MarkItMistral` with explicit typed arguments instead of unpacking a `dict[str, object]`

`ruff`, `ty`, and the test suite (139 passing in the touched areas) are green.

Note: CFF 1.3.0 is the proposed schema adding `affiliation`/`ror`; GitHub accepts it. The pip `cffconvert` tool does not recognize 1.3.0 yet.