### PR TITLE
Add Zenodo concept DOI

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -30,5 +30,5 @@ keywords:
   - pubmed
   - openalex
   - semantic-scholar
-# Concept (all-versions) DOI is added after the first Zenodo release; it always
-# resolves to the latest version.
+# Concept (all-versions) DOI; always resolves to the latest release.
+doi: "10.5281/zenodo.20696765"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OpenCite
 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20696765.svg)](https://doi.org/10.5281/zenodo.20696765)
+
 Academic literature search, citation management, and PDF retrieval CLI.
 
 Searches Semantic Scholar, OpenAlex, PubMed, arXiv, bioRxiv, medRxiv, OSF Preprints (PsyArXiv/SocArXiv/...), Zenodo, Figshare, CrossRef, and CORE in parallel, deduplicates results, and supports BibTeX output, citation graph traversal, PDF retrieval (with HTML full-text shortcuts for arXiv ar5iv and bioRxiv `.full`), batch downloads, and PDF-to-markdown conversion.


### PR DESCRIPTION
Adds the concept (all-versions) DOI (10.5281/zenodo.20696765) to CITATION.cff and a DOI badge to the README. Resolves to the latest release; stable across versions.